### PR TITLE
change pagination navigation component alignment to center within container

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -576,7 +576,7 @@ This enables two modes of build work.
 <ul>
   <li><span class="distinct">body.archive-page > main > nav.pagination</span>, as the last child of <span class="distinct">body > main</span> </li>
   <li><span class="distinct">body.person-page > main > nav.pagination</span>, as the last child of <span class="distinct">body > main</span> </li>
-
+  <li><span class="distinct">body.search-index > main > nav.pagination</span>, as the last child of <span class="distinct">body > main</span> </li>
 
 </ul>
 

--- a/src/css/vocabulary.css
+++ b/src/css/vocabulary.css
@@ -1566,7 +1566,8 @@ main .authored-posts.highlight article {
 }
 
 nav.pagination {
-    grid-column: span 3;
+    grid-column: span 2;
+    margin: 0 auto;
 }
 
 nav.pagination ol {


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'.  -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
<!-- Replace [issue number] with the issue number (don't leave the square brackets)--likewise for [issue author]. -->
- Fixes #4

## Description
* changes the default alignment of the [pagination navigation component](https://vocabulary-docs.netlify.app/#pagination-nav) to be centered to its parent container, rather than left aligned.
  - `archive-page` preview: https://deploy-preview-41--vocabulary-docs.netlify.app/specimen/contexts/archive-page.html
  - `person-page` preview: https://deploy-preview-41--vocabulary-docs.netlify.app/specimen/contexts/person-page.html
  - `search-index` preview: https://deploy-preview-41--vocabulary-docs.netlify.app/specimen/contexts/search-index.html
* corrects documented contexts for this component to now include the `search-index` page level context.
  - preview: https://deploy-preview-41--vocabulary-docs.netlify.app/#pagination-nav
  
 ## Screenshots

### Before
<img width="769" alt="Screen Shot 2024-06-17 at 12 04 46 PM" src="https://github.com/creativecommons/vocabulary/assets/109087089/235e6b1b-fbbf-4dff-b140-675bf2ef22a8">

### After
<img width="795" alt="Screen Shot 2024-06-17 at 12 04 23 PM" src="https://github.com/creativecommons/vocabulary/assets/109087089/1a2a801a-85a7-420a-8d46-bbb86ef64ecc">


## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
