### PR TITLE
Issue #45 fix active state

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "liveServer.settings.port": 5501
+}

--- a/specimen/index-logo.html
+++ b/specimen/index-logo.html
@@ -18,12 +18,12 @@
         <button class="expand-menu">Menu</button>
         <nav class="primary-menu">
             <ul>
-                <li><a href="#">Who We Are</a></li>
-                <li><a href="#">What We Do</a></li>
-                <li><a href="#">Licenses and Tools</a></li>
-                <li><a href="#">Blog</a></li>
-                <li><a href="#">Support Us</a></li>
-                <li><a class="attention" href="https://summit.creativecommons.org/">Global Summit 2023</a></li>
+                <li><a href="#" class="active">Who We Are</a></li>
+                <li><a href="#" class="active">What We Do</a></li>
+                <li><a href="#" class="active">Licenses and Tools</a></li>
+                <li><a href="#" class="active">Blog</a></li>
+                <li><a href="#" class="active">Support Us</a></li>
+                <li><a class="attention active" href="https://summit.creativecommons.org/">Global Summit 2023</a></li>
             </ul>
         </nav>
 

--- a/src/css/vocabulary.css
+++ b/src/css/vocabulary.css
@@ -938,6 +938,7 @@ body > header .masthead .primary-menu ul li a.attention {
     border-radius: 4px;
 }
 
+
 /* Hover Effect for Link */
 body > header .masthead .primary-menu ul li a.attention:hover {
     background: var(--vocabulary-brand-color-soft-turquoise); 

--- a/src/css/vocabulary.css
+++ b/src/css/vocabulary.css
@@ -938,6 +938,21 @@ body > header .masthead .primary-menu ul li a.attention {
     border-radius: 4px;
 }
 
+/* Hover Effect for Link */
+body > header .masthead .primary-menu ul li a.attention:hover {
+    background: var(--vocabulary-brand-color-soft-turquoise); 
+    color: white;
+}
+
+/* New Active State */
+body > header .masthead .primary-menu ul li a.active {
+    color: #ffff;
+    background-color: var(--vocabulary-brand-color-tomato); 
+    padding: 0.5em;
+    border-radius: 4px;
+    font-weight: bold;
+}
+
 body > header button.expand-menu {
     display: none;
 }


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'.  -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
<!-- Replace [issue number] with the issue number (don't leave the square brackets)--likewise for [issue author]. -->
- Fixes #45 by @possumbilities

## Description
<!-- Concisely describe what the pull request does. -->
This PR addresses issue #45 by adding active states to the primary menu navigation. The changes include:

- Adding an active class for the primary menu items.
- Adjusting the hover and attention styles to align with the brand colors.

Fixes #45.
## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->
Changes Made: 
- I updated the HTML for the primary menu to include the active class(.active) for the relevant navigation items.
- I also adjusted the CSS styles to show how active states are displayed, ensuring consistency with the brand colors.
## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or comment out this section entirely. -->

## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [ ] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main` or `master`).
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
