### PR TITLE
 Home page hero section interface Adjusted

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -3,7 +3,6 @@
 body {
     width: 65%;
     font-size: 1.2em;
-
     padding: 1em;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "vocabulary",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/specimen/contexts/home-index.html
+++ b/specimen/contexts/home-index.html
@@ -15,7 +15,7 @@
 </head>
 
 <body class="home-narrative">
-<a class="skip-to-content" href="#main-content-marker">Skip to content</a>
+<!-- <a class="skip-to-content" href="#main-content-marker">Skip to content</a> -->
 
 <header>
     <div class="masthead">
@@ -91,19 +91,24 @@
 
 <main>
 
-<article class="topic-summary">
-    <h2>Better Sharing, Brighter Future</h2>
-    <figure>
-        <iframe style="width: 100%;" title="Twenty Years of Creative Commons (in Sixty Seconds)" src="https://player.vimeo.com/video/777912896?h=016f97b875&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479" frameborder="0" allowfullscreen="allowfullscreen" data-ready="true"></iframe>
-        <span class="attribution">
-            “<a href="https://www.flickr.com/photos/creativecommons/52543574218/">Twenty Years of Creative Commons (in Sixty Seconds)</a>” by&nbsp;<a href="http://www.junell.net/">Ryan Junell</a>&nbsp;and&nbsp;<a href="https://www.linkedin.com/in/gotisbrown/">Glenn Otis Brown</a>&nbsp;for&nbsp;<a href="https://creativecommons.org/">Creative Commons</a>&nbsp;is licensed via&nbsp;<a href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>&nbsp;and includes adaptations of the multiple open and public domain works. View full licensing and attribution information about all works included in the video&nbsp;<a href="https://www.flickr.com/photos/creativecommons/52543574218/">on Flickr</a>.
-        </span>
-    </figure>
-    <div class="description">
-        <p>Creative Commons is an international nonprofit organization that empowers people to grow and sustain the thriving commons of shared knowledge and culture we need to address the world's most pressing challenges and create a brighter future for all.</p>
-        <a href="#">Learn more</a>
-    </div>
-</article>
+    <article class="topic-summary">
+        <!-- Text section -->
+        <div class="description">
+            <h2 class="header">Better Sharing, Brighter Future</h2>
+            <p class="hero-text">Creative Commons is an international nonprofit organization that empowers people to grow and sustain the thriving commons of shared knowledge and culture we need to address the world's most pressing challenges and create a brighter future for all.</p>
+            <a href="#" class="learn-link">Learn more</a>
+        </div>
+    
+        <!-- Video section -->
+            <figure class="iframe-container">
+                <iframe class="iframe-image" title="Twenty Years of Creative Commons (in Sixty Seconds)" src="https://player.vimeo.com/video/777912896?h=016f97b875&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479" frameborder="0" allowfullscreen="allowfullscreen" data-ready="true"></iframe>
+                <span class="attribution">
+                    “<a href="https://www.flickr.com/photos/creativecommons/52543574218/">Twenty Years of Creative Commons (in Sixty Seconds)</a>” by&nbsp;<a href="http://www.junell.net/">Ryan Junell</a>&nbsp;and&nbsp;<a href="https://www.linkedin.com/in/gotisbrown/">Glenn Otis Brown</a>&nbsp;for&nbsp;<a href="https://creativecommons.org/">Creative Commons</a>&nbsp;is licensed via&nbsp;<a href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>&nbsp;and includes adaptations of the multiple open and public domain works. View full licensing and attribution information about all works included in the video&nbsp;<a href="https://www.flickr.com/photos/creativecommons/52543574218/">on Flickr</a>.
+                </span>
+            </figure>
+    </article>
+    
+    
 
 
 <article class="case-studies">

--- a/specimen/style.css
+++ b/specimen/style.css
@@ -1,2 +1,39 @@
 @import '../src/css/vocabulary.css' layer(vocabulary);
 @import '../specimen/tests/grid-test.css' layer(vocabulary);
+
+.topic-summary {
+   display: flex;
+ /* justify-items:center; */
+align-items: start;
+gap: 3%;
+width: 100%;
+margin-top: 4rem;
+}
+
+.description {
+    font-size: .8em;
+}
+
+
+.iframe-image {
+
+    width: 400px;
+    height: 200px;
+    background: black;
+
+}
+
+.header{
+    font-size: 2em;;
+}
+
+.attribution{
+    font-size: .9em;
+}
+.hero-text{
+    margin-bottom: .8em;
+}
+.learn-link{
+    font-weight: bold;
+    font-size: 1.5em;
+}

--- a/src/css/vocabulary.css
+++ b/src/css/vocabulary.css
@@ -33,7 +33,7 @@ EX:
     position: absolute;
     top: 0;
     left: 0;
-    margin: -1000px;
+    /* margin: -1000px; */
 }
 
 .skip-to-content:focus {
@@ -202,9 +202,7 @@ a.more {
 
 /* .posts .related variant context */
 
-.posts.related {
-    
-}
+
 
 /* <main> level context */
 
@@ -1461,10 +1459,7 @@ body > footer .license svg {
 
 
 /* archive-page context */
-.archive-page main {
 
-    
-}
 
 /* blog-index context */
 


### PR DESCRIPTION
## Fixes
Adjusted the hero section layout to look a bit like the current site's.


## Description
This pull request contains changes made to the interface of the Home page hero section.



## Screenshots
This is the old interface for Vocabulary interface:

<img width="937" alt="CCOldHomeInterface" src="https://github.com/user-attachments/assets/c0d2c80e-66f8-43fb-b72b-d4cdeabbe276">

Current Home page hero interface: 

<img width="956" alt="CCNewHomInterface" src="https://github.com/user-attachments/assets/f5497a25-bae9-4b3c-9156-de36ed222b4d">

<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [ x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [ xx] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ x] I tried running the project locally and verified that there are no
  visible errors.
