### PR TITLE
Made design system ui mobile responsive

### DIFF
--- a/src/css/vocabulary.css
+++ b/src/css/vocabulary.css
@@ -215,7 +215,7 @@ main {
     width: 100%;
     margin: 0;
     margin-bottom: 8em;
-    padding: 0;
+    padding:0  16px 0 16px;
     grid-column: 1 / 12;
 }
 
@@ -783,6 +783,7 @@ body > header {
     flex-wrap: wrap;
     position: relative;
     margin-bottom: 2em;
+
     /* padding: 0 var(--vocabulary-page-edges-space); */
 }
 

--- a/src/css/vocabulary.css
+++ b/src/css/vocabulary.css
@@ -29,6 +29,10 @@ EX:
 @import 'library-vars.css';
 
 /* utilities */
+:root{
+  box-sizing: border-box;
+}
+
 .skip-to-content {
     position: absolute;
     top: 0;
@@ -51,10 +55,13 @@ body {
     -moz-osx-font-smoothing: grayscale;
     -webkit-font-smoothing: antialiased;
 }
+body span {
+     padding:1rem
+}
 
 a.more {
     padding: .4em .7em;
-
+    margin:0 1rem;
     background: black;
     color: white;
     font-family: 'Roboto Condensed';
@@ -107,6 +114,7 @@ a.more {
     font-weight: 700;
     text-transform: none;
     text-align: left;
+    padding:0 16px;
 }
 
 .posts .post {
@@ -133,7 +141,6 @@ a.more {
 
 .posts .post h2, .posts .post h3 {
     grid-area: title;
-    width: 100%;
     margin-top: 0.83em;
 
     font-family: 'Roboto Condensed';
@@ -215,7 +222,6 @@ main {
     width: 100%;
     margin: 0;
     margin-bottom: 8em;
-    padding:0  16px 0 16px;
     grid-column: 1 / 12;
 }
 
@@ -257,7 +263,7 @@ main > header h1 {
     grid: 0 / auto;
 
     font-family: 'Roboto Condensed';
-    font-size: 3.56em;
+    font-size: 2.6rem;
     font-style: normal;
     font-weight: 700;
     /* text-transform: uppercase; */
@@ -389,8 +395,7 @@ main > aside.sidebar .attention a {
 }
 
 main h2 {
-    width: 100%;
-
+    padding:0 1rem;
     font-family: 'Roboto Condensed';
     font-style: normal;
     font-weight: 700;
@@ -403,6 +408,7 @@ main h3 {
     font-style: normal;
     font-weight: 700;
     font-size: 1.75em;
+    padding:0 1rem;
     text-transform: none;
 }
 
@@ -454,7 +460,7 @@ main a {
 
 main p {
     margin-bottom: 2em;
-
+    padding: 0 1rem ;
     font-family: 'Source Sans Pro';
     font-size: 1.5em;
     font-style: normal;
@@ -464,7 +470,7 @@ main p {
 
 main ul, main ol {
     margin: 0 0 2em 1em;
-    padding: 0;
+    padding: 0 1rem;
 
     font-family: 'Source Sans Pro';
     font-size: 1.5rem;
@@ -522,7 +528,7 @@ main > article figure img, main > figure img {
 main figure .attribution {
     display: block;
     margin-top: 1em;
-
+    padding:0 1rem;
     font-family: 'Source Sans Pro';
     font-style: normal;
     font-weight: 400;
@@ -1560,7 +1566,7 @@ body > footer .license svg {
 
 .blog-index main .posts.featured ul li:nth-of-type(1) article.post {
     margin-bottom: 1em;
-    padding: 4em;
+    /* padding: 4em; */
 }
 
 
@@ -1737,7 +1743,7 @@ body > footer .license svg {
 
 .person-page main > header h1 {
     grid-column-start: 2;
-
+    padding:0 1rem;
     margin-bottom: .1em;
 
 }
@@ -1857,6 +1863,9 @@ body > footer .license svg {
         display: flex;
         flex-wrap: wrap;
     }
+    main article.posts.related ul {
+        grid-template-columns: 1fr 1fr 1fr;
+    }
 }
 
 @media (max-width: 705px) {
@@ -1919,9 +1928,9 @@ body > footer .license svg {
         display: block;
     }
 
-    .blog-index main article.posts.featured > ul li:nth-child(1) {
+    /* .blog-index main article.posts.featured > ul li:nth-child(1) {
         padding: 2em;
-    }
+    } */
 
     .blog-index main .posts {
         padding: 0 5%;
@@ -1946,7 +1955,9 @@ body > footer .license svg {
     body > footer {
         display: block;
     }
-
+    main article.posts.related ul {
+        grid-template-columns: 1fr 1fr;
+    }
     body > footer > nav {
         margin-top: 1em;
         margin-bottom: 3em;
@@ -2024,10 +2035,15 @@ body > footer .license svg {
     body > footer .footer-menu ul {
         display: block;
     }
+    main > header h1{
+        font-size: 1.6rem;
+    }
 }
 
 @media (max-width: 425px) {
-
+    main article.posts.related ul {
+        grid-template-columns: 1fr;
+    }
     .blog-index .attribution-list {
       padding: 2em;
     }


### PR DESCRIPTION
[WIP] [Bug] Mobile responsibility UI issue

## Fixes
- reduced font size of h1 tag to 2.6 rem on larger devices and 1.6rem on smaller devices 

- Gave padding of  1rem  on the left and right side  to almost all elements 

- Added a **:root** configuration  were i mentioned **box -sizing to border box** at the top of **vocabulary.css** so that the padding and margin given to element remain restricted to the element and won't  cause any abnormalities in the ui

- Adjusted styling of **a.more** gave it a margin of 1rem 

- Added new style class  **body span** and gave  it a padding of 1rem 

- Adjusting the styling of  **article.Related post ul >li** they were causing footer to shrink more as the were not wrapping when screen sized reduces  Made a  griid template column appropriate to the size of window  for them so they can adjust with the screen size

- Removed the  width of 100% on **h2,  .posts .post h2, .posts .post h3**  they were causing overflow on the body  shrinking  other elements

 - **.blog-index main article.posts.featured > ul li:nth-child(1), .blog-index main .posts.featured ul li:nth-of-type(1) article.post**
 on these class I Commented  padding  for device  below the width of 705px because it was causing overflow on blog index index page


on **.person-page main > header h1** I Added padding  of 1rem to it

- Fixes #68 by @SisiVero

## Description


Recent changes improved the page's responsiveness by adjusting the font size of h1 for different screen sizes, adding consistent padding, and applying global box-sizing. The layout was enhanced by modifying related post styling to prevent footer shrinking, removing width settings on certain headers to avoid overflow, and addressing padding inconsistencies for smaller screens.

## This  PR fixes
- home-index page.html 
- default-page.html
- blog-post.html
- blog-index.html

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.



## Developer Certificate of Origin

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
