### PR TITLE
Initial commit for fixing icon flash issue

### DIFF
--- a/src/css/library-vars.css
+++ b/src/css/library-vars.css
@@ -295,3 +295,26 @@ leaving room for semantic and accessible implementation choices  */
     --icon-sprite: var(--cc-logo);
 }
 
+.icon-replace:focus {
+    outline: 2px solid blue; 
+}
+
+.icon-replace:before {
+    content: '';
+    display: block;
+    height: 100%; 
+    width: 100%; 
+    background-color: var(--icon-sprite-color);
+    -webkit-mask-image: var(--icon-sprite);
+    mask-image: var(--icon-sprite);
+    -webkit-mask-size: contain;
+    mask-size: contain;
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+}
+
+
+.icon-replace:hover:before,
+.icon-replace:focus:before {
+    background-color: purple; 
+}


### PR DESCRIPTION
## Fixes
Fixes #10 by @possumbilities 

## Description
This PR fixes the issue where logos and social icons flash purple briefly when clicked. 
The fix moves the SVG mask to a child pseudo-element to allow the standard focus outline behavior and prevent the purple flash.

## Technical details
The solution involves moving the SVG mask to a `:before` pseudo-element, which allows the main element to have a standard focus outline without the color flash issue. This method ensures that the icon styles are preserved while eliminating the visual glitch.

## Tests
1. Click on any of the social icons.
2. Verify that the icon no longer flashes purple.
3. Check that the focus outline is displayed as expected when the icon is clicked.



## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title.
- [x] My pull request targets the default branch.
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified there are no visible errors.


[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
