### PR TITLE
fixes issue Named [Bug] person-page context profile image does not support mixed aspect ratios, expects a smaller square 

### DIFF
--- a/src/css/vocabulary.css
+++ b/src/css/vocabulary.css
@@ -1775,7 +1775,7 @@ body > footer .license svg {
     box-sizing: border-box;
 
     width: 100%;
-
+    max-height: 21.8rem;
     border: 16px solid white;
 }
 


### PR DESCRIPTION

## Description
- fixes #19  by @possumbilities 
- Introduced max height on the image in the following class  `.person-page main > header figure img`
- added max height on the image so it won't stretch more than a specific value when screen stretches allowing image of any aspect ratio not to overflow from the parent and remain of specific size

## Technical details
- Images not having max height will stretch and elongate as much as their as aspect ratio to prevent this we can use max height to prevent image from elongating more than a specific value

## Tests
- tested in local environment and it worked also applied same styles to the https://creativecommons.org/person/javahercreativecommons-org/ using developer tools under same class it worked their as well

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.



## Developer Certificate of Origin
For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
