### PR TITLE
Added Padding to the main tags and aligned their headers appropriately  

### DIFF
--- a/specimen/contexts/blog-post.html
+++ b/specimen/contexts/blog-post.html
@@ -179,7 +179,7 @@
         <p>If you'd like to read more in this series, please do!</p>
     </aside>
 
-    <span class="pub-date">published July 22, 2023</span>
+    <span class="pub-date">Posted 22 July 2023</span>
 
     <article class="tags">
         <h2>Tags</h2>

--- a/specimen/contexts/blog-post.html
+++ b/specimen/contexts/blog-post.html
@@ -179,7 +179,7 @@
         <p>If you'd like to read more in this series, please do!</p>
     </aside>
 
-    <span class="pub-date">Posted 22 July 2023</span>
+    <span class="pub-date">Published July 22, 2023</span>
 
     <article class="tags">
         <h2>Tags</h2>

--- a/specimen/contexts/blog-post.html
+++ b/specimen/contexts/blog-post.html
@@ -179,7 +179,7 @@
         <p>If you'd like to read more in this series, please do!</p>
     </aside>
 
-    <span class="pub-date">Published July 22, 2023</span>
+    <span class="pub-date">published July 22, 2023</span>
 
     <article class="tags">
         <h2>Tags</h2>

--- a/src/css/vocabulary.css
+++ b/src/css/vocabulary.css
@@ -1918,9 +1918,9 @@ body > footer .license svg {
         display: block;
     }
 
-    .blog-index main article.posts.featured > ul li:nth-child(1) {
-        padding: 2em;
-    }
+    /* .blog-index main article.posts.featured > ul li:nth-child(1) {
+       
+    } */
 
     .blog-index main .posts {
         padding: 0 5%;
@@ -1962,6 +1962,8 @@ body > footer .license svg {
     main {
         display: block;
         width: 100%;
+        padding: 1em;
+        box-sizing: border-box;
     }
 
     main > aside .attention {
@@ -1969,7 +1971,7 @@ body > footer .license svg {
     }
 
     main > header:before {
-        left: 0;
+        left: -1em;
     }
 
     .posts article figure {


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'.  -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
<!-- Replace [issue number] with the issue number (don't leave the square brackets)--likewise for [issue author]. -->
- Fixes #68  by @Sisivero

## Description
<!-- Concisely describe what the pull request does. -->
This pull requests adds box-sizing border-box and  1em padding to the main tag across mobile view and aligns the header tag in main by moving it left by -1em. It also removes the padding on the first child of the list on the featured post in blog-index.html on mobile view

## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->
This was implemented by adding boxing-sizing border-box to the main tag in the media query for max-width: 680px, removing the padding for the first child of the list on the featured post in blog-index.html in the media query for max-width:705px and changing the left position from 0 to -1em for the header::before also in the media query for max-width: 680px  all located  in vocalbulary.css 

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or comment out this section entirely. -->
Check the appearance of the main section and header tag across pages of the website

## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
