### PR TITLE
Added alt to img tags in vocabulary documentation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -427,7 +427,7 @@ This enables two modes of build work.
       <li>
         <article>
           <figure>
-            <img src="PATH/TO/image.png">
+            <img src="PATH/TO/image.png" alt="Alternate Text">
             <span class="attribution">attribution here</span>
           </figure>
         </article>
@@ -481,7 +481,7 @@ This enables two modes of build work.
     <h3><a href="#">Name Here</a></h3>
     <span class="title">Position/Title here</span>
     <figure>
-      <img src="PATH/TO/profile.jpg" />
+      <img src="PATH/TO/profile.jpg" alt="Description of the image"/>
     </figure>
     <p>Truncated bio here&hellip;</p>
   </article>
@@ -509,7 +509,7 @@ This enables two modes of build work.
           <h3><a href="#">Name Here</a></h3>
           <span class="title">Position/Title here</span>
           <figure>
-            <img src="PATH/TO/profile.jpg" />
+            <img src="PATH/TO/profile.jpg" alt="Description of the image"/>
           </figure>
           <p>Truncated bio here&hellip;</p>
          </article>
@@ -546,7 +546,7 @@ This enables two modes of build work.
 
     </header>
     <figure>
-      <img src="PATH/TO/image.jpg" />
+      <img src="PATH/TO/image.jpg" alt="Description of the image"/>
       <span class="attribution">attribution here</span>
     </figure>
     <p>truncated teaser excerpt </p>
@@ -588,7 +588,7 @@ This enables two modes of build work.
 
       </header>
       <figure>
-        <img src="PATH/TO/image.jpg" />
+        <img src="PATH/TO/image.jpg" alt="Description of the image"/>
         <span class="attribution">attribution here</span>
       </figure>
       <p>truncated teaser excerpt </p>
@@ -856,7 +856,7 @@ This enables two modes of build work.
     <ul>
       <li>
         <figure>
-          <img src="PATH/TO/home.jpg" />
+          <img src="PATH/TO/home.jpg" alt="Description of the image"/>
           <span class="attribution">attribution here</span>
          </figure>
        </li>
@@ -987,7 +987,7 @@ This enables two modes of build work.
     <span class="pronouns">pronouns optionally here</span>
 
     <figure>
-      <img src="PATH/TO/profile.jpg" />
+      <img src="PATH/TO/profile.jpg" alt="Description of the image"/>
       <span class="attribution">attribution here</span>
      </figure>
      <div class="bio">


### PR DESCRIPTION
## Fixes
- Fixes #106  by @SisiVero

## Description
This PR adds "alt" to img tags in the documentation in order to enhance the design system while having UX in mind.

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.
