### PR TITLE
Change button text when active or inactive.

### DIFF
--- a/src/js/vocabulary.js
+++ b/src/js/vocabulary.js
@@ -1,35 +1,35 @@
-const exploreButton = document.querySelector("button.explore");
-const explorePanel = document.querySelector(".explore-panel");
+const exploreButton = document.querySelector('button.explore');
+const explorePanel = document.querySelector('.explore-panel');
 
 // explorePanel.classList.add('hide');
 
-exploreButton.addEventListener("click", (event) => {
-  explorePanel.classList.toggle("expand");
+exploreButton.addEventListener('click', (event) => {
+  explorePanel.classList.toggle('expand');
   // explorePanel.classList.toggle('hide');
 });
 
-const menuButton = document.querySelector("button.expand-menu");
-const menuPanel = document.querySelector(".primary-menu");
+const menuButton = document.querySelector('button.expand-menu');
+const menuPanel = document.querySelector('.primary-menu');
 
-menuButton.addEventListener("click", (event) => {
-  menuPanel.classList.toggle("expand");
+menuButton.addEventListener('click', (event) => {
+  menuPanel.classList.toggle('expand');
   // explorePanel.classList.toggle('hide');
 });
 
-const attributionButton = document.querySelector("button.expand-attribution");
-const attributionPanel = document.querySelector(".attribution-panel");
+const attributionButton = document.querySelector('button.expand-attribution');
+const attributionPanel = document.querySelector('.attribution-panel');
 
 if (attributionButton !== null && attributionPanel !== null) {
-  attributionButton.addEventListener("click", () => {
+  attributionButton.addEventListener('click', () => {
     // Toggle the class to change the active state
-    attributionButton.classList.toggle("selected");
-    attributionPanel.classList.toggle("expand");
+    attributionButton.classList.toggle('selected');
+    attributionPanel.classList.toggle('expand');
 
     // Check if the button is in the active state and change the text accordingly
-    if (attributionButton.classList.contains("selected")) {
-      attributionButton.textContent = "Close"; // When it is opend or active, the btn text changes to Close
+    if (attributionButton.classList.contains('selected')) {
+      attributionButton.textContent = 'Close'; // When it is opend or active, the btn text changes to Close
     } else {
-      attributionButton.textContent = "View"; // When it is closed it changes to View
+      attributionButton.textContent = 'View'; // When it is closed it changes to View
     }
   });
 }

--- a/src/js/vocabulary.js
+++ b/src/js/vocabulary.js
@@ -1,32 +1,35 @@
-const exploreButton = document.querySelector('button.explore');
-const explorePanel = document.querySelector('.explore-panel');
+const exploreButton = document.querySelector("button.explore");
+const explorePanel = document.querySelector(".explore-panel");
 
 // explorePanel.classList.add('hide');
 
-exploreButton.addEventListener('click', (event) => {
-    explorePanel.classList.toggle('expand');
-    // explorePanel.classList.toggle('hide');
+exploreButton.addEventListener("click", (event) => {
+  explorePanel.classList.toggle("expand");
+  // explorePanel.classList.toggle('hide');
 });
 
+const menuButton = document.querySelector("button.expand-menu");
+const menuPanel = document.querySelector(".primary-menu");
 
-const menuButton = document.querySelector('button.expand-menu');
-const menuPanel = document.querySelector('.primary-menu');
-
-menuButton.addEventListener('click', (event) => {
-    menuPanel.classList.toggle('expand');
-    // explorePanel.classList.toggle('hide');
+menuButton.addEventListener("click", (event) => {
+  menuPanel.classList.toggle("expand");
+  // explorePanel.classList.toggle('hide');
 });
 
+const attributionButton = document.querySelector("button.expand-attribution");
+const attributionPanel = document.querySelector(".attribution-panel");
 
-const attributionButton = document.querySelector('button.expand-attribution');
-const attributionPanel = document.querySelector('.attribution-panel');
+if (attributionButton !== null && attributionPanel !== null) {
+  attributionButton.addEventListener("click", () => {
+    // Toggle the class to change the active state
+    attributionButton.classList.toggle("selected");
+    attributionPanel.classList.toggle("expand");
 
-if (attributionButton !== null && attributionPanel !== null ) {
-
-    attributionButton.addEventListener('click', (event) => {
-        attributionButton.classList.toggle('selected');
-        attributionPanel.classList.toggle('expand');
-        // explorePanel.classList.toggle('hide');
-    });
-
+    // Check if the button is in the active state and change the text accordingly
+    if (attributionButton.classList.contains("selected")) {
+      attributionButton.textContent = "Close"; // When it is opend or active, the btn text changes to Close
+    } else {
+      attributionButton.textContent = "View"; // When it is closed it changes to View
+    }
+  });
 }


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'.  -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
<!-- Replace [issue number] with the issue number (don't leave the square brackets)--likewise for [issue author]. -->
- Fixes #89  by @SisiVero

## Description
This PR address the issue #89 . Active and Inactive feature was added to blog-index.html View button. This changes the text from "View" to "Close" when it is open and vice versa.

## Technical details
No extra class or id was created. The already existed Js Function for the button was updated to includ the feature.

## Tests
1. When a user clicks on the View button and it opens the panel, the text changes from "view" to "close", thereby enhancing UX.

## Screenshots
When the button is inactive or closed:
<img width="837" alt="closed" src="https://github.com/user-attachments/assets/cc3eb2b3-683a-4cd1-9ae2-bfe22eb0f7f1">

when the button is active or opened:
<img width="836" alt="opened" src="https://github.com/user-attachments/assets/dfde37a8-0b3d-4464-93fc-f3ab49300ba5">

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [] I added or updated tests for the changes I made (if applicable).
- [] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

