### PR TITLE
[Fix] Mobile responsiveness issues in search-index.html

### DIFF
--- a/src/css/vocabulary.css
+++ b/src/css/vocabulary.css
@@ -1590,7 +1590,7 @@ body > footer .license svg {
 
 .search-index .search-form form input {
     flex: 1;
-    width: 100%;
+    /* width: 100%; */
     height: 4em;
     padding: .2em 1em;
 
@@ -1856,6 +1856,10 @@ body > footer .license svg {
         display: flex;
         flex-wrap: wrap;
     }
+
+    main > .posts{
+        grid-column: 4 / span 5;
+    }
 }
 
 @media (max-width: 705px) {
@@ -1968,13 +1972,25 @@ body > footer .license svg {
         margin-bottom: 5em;
     }
 
+    main > header > *{
+        margin: 0 var(--vocabulary-page-edges-space);
+    }
+
+    main > header h1{
+        width: auto;
+    }
+
     main > header:before {
         left: 0;
     }
 
-    .posts article figure {
+    .posts .post figure {
         width: 100%;
         flex: initial;
+    }
+
+    .posts .post{
+        margin: 0 var(--vocabulary-page-edges-space);
     }
 
     .team-index main > header {
@@ -2012,6 +2028,10 @@ body > footer .license svg {
 
     main nav.pagination ol li {
         line-height: 250%;
+    }
+
+    .search-index main > header:before {
+        left: 0;
     }
 }
 


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'.  -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
<!-- Replace [issue number] with the issue number (don't leave the square brackets)--likewise for [issue author]. -->
- Fixes #142  by @wendy640

## Description
<!-- Concisely describe what the pull request does. -->
This PR resolves all the mobile responsiveness issues on the search-index.html page. Making it responsive all the way to the standard 320px screen width.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->
This was implemented using the already existing design guidelines and implementation
-By adjusting the `grid-column` property, based on the screen width
-Applying the var(--vocabulary-page-edges-space) value as margin for smaller screen sizes, so the content is not directly against the screen bezels
-Reseting styles that break the content arrangement on smaller screens.

This approach also put into consideration other context pages, making changes that would contribute towards resolving mobile responsiveness issues on other context pages.

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or comment out this section entirely. -->
- Fork and the clone the `creativecommons/vocabulary` project unto your local machine.
- Launch the `search-index.html` file on your browser
- Toggle the developer console by hitting `Ctrl + shift + I` and then toggling the option for device toolbar.
- Test the UI at all screen sizes for mobile responsiveness by visual inspection of each element. Particularly screen sizes lesser than 680px
- Test the UI on various browsers for compatibility.

<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->
![image](https://github.com/user-attachments/assets/8ae7b2ad-6681-474a-b27e-3ce0f73c5d54)
![image](https://github.com/user-attachments/assets/1a2ce035-07a3-4dd2-8143-738247e1c289)
![image](https://github.com/user-attachments/assets/14f4296f-5c28-4ddc-b2af-2cb892f8f8ce)
![image](https://github.com/user-attachments/assets/c0e26d6e-2584-4aec-a90d-08355ead973c)
![image](https://github.com/user-attachments/assets/45f6102f-5400-44ac-aec7-bb9d4fa21399)
![image](https://github.com/user-attachments/assets/03291afb-90e8-4372-b1eb-54ceedce1fed)
![image](https://github.com/user-attachments/assets/c6561d57-bb7e-4739-8d82-b66918fe9a5a)
![image](https://github.com/user-attachments/assets/5827c4af-e595-4388-9def-8894845d7fe5)


## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
