### PR TITLE
Add Netlify deployment script and ignore deployed data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 .AppleDouble
 .LSOverride
 
-# published files
+# published
 docs/_redirects
 docs/specimen/
 docs/vocabulary/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,10 @@
+# macOS general
+# https://github.com/github/gitignore/blob/main/Global/macOS.gitignore
 .DS_Store
+.AppleDouble
+.LSOverride
+
+# published files
+docs/_redirects
+docs/specimen/
+docs/vocabulary/

--- a/netlify-deploy.sh
+++ b/netlify-deploy.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+# (POSIX / Dash compatible)
+set -o errexit
+set -o nounset
+
+# https://en.wikipedia.org/wiki/ANSI_escape_code
+E0="$(printf "\033[0m")"        # reset
+E30="$(printf "\033[30m")"      # black foreground
+E107="$(printf "\033[107m")"    # bright white background
+
+#### FUNCTIONS ################################################################
+
+
+print_header() {
+    # Print 80 character wide black on white heading with time
+    printf "${E30}${E107}# %-69s$(date '+%T') ${E0}\n" "${@}"
+}
+
+
+remove_previous_from_docs() {
+    # shellcheck disable=SC2016
+    print_header 'Remove previous publish from the `docs/` directory'
+    rm -rf docs/_redirects docs/specimen docs/vocabulary
+    mkdir -p docs/specimen docs/vocabulary
+    echo 'done.'
+    echo
+}
+
+
+publish_to_docs() {
+    # shellcheck disable=SC2016
+    print_header 'Publish to the `docs/` directory'
+    cp -a _redirects docs/
+    cp -a specimen/* docs/specimen/
+    cp -a src/* docs/vocabulary/
+    echo 'done.'
+    echo
+}
+
+
+#### MAIN #####################################################################
+
+remove_previous_from_docs
+publish_to_docs


### PR DESCRIPTION
## Description
Add Netlify deployment script and ignore deployed data

Once the deployment script lands, we can update Netlify config. Then we can extend deployment operations without having to update Netlify configuration.

In the futture, it will also be trivial to extend it with a `local-deploy.sh` script (ex. call `netlify-deploy.sh` and restart docker service).


## Technical details
I made some assumptions that may be incorrect 🤞🏻 


## Tests
Checked with both:
- [koalaman/shellcheck](https://github.com/koalaman/shellcheck): _ShellCheck, a static analysis tool for shell scripts_
- `checkbashisms` ([Ubuntu Manpage: checkbashisms - check for bashisms in /bin/sh scripts](https://manpages.ubuntu.com/manpages/noble/en/man1/checkbashisms.1.html))

(both can be installed via Homebrew)

## Screenshots 😜 
<img width="484" alt="Screenshot 2024-10-08 at 14 17 16" src="https://github.com/user-attachments/assets/fefd9a89-71fc-4973-a09e-ebe1b095e5d5">


## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
