### PR TITLE
Fix newsletter form validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.vscode

--- a/specimen/contexts/archive-page.html
+++ b/specimen/contexts/archive-page.html
@@ -265,12 +265,15 @@
     <div class="subscribe">
     <h2>Subscribe to our Newsletter</h2>
     <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank" novalidate="">
-        <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required="">
-        <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-        <div style="position: absolute; left: -5000px" aria-hidden="true">
-          <input type="text" name="b_fd30364b6577b471373d6076c_4603fe102a" tabindex="-1" value="">
+        <div class="input-wrap">
+            <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required="">
+            <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+            <div style="position: absolute; left: -5000px" aria-hidden="true">
+              <input type="text" name="b_fd30364b6577b471373d6076c_4603fe102a" tabindex="-1" value="">
+            </div>
+            <input type="submit" value="subscribe" id="mc-embedded-subscribe" class="button small">
         </div>
-        <input type="submit" value="subscribe" id="mc-embedded-subscribe" class="button small">
+        <span id="emailFeedback" class="error-message"></span>
       </form>
     </div>
 
@@ -294,7 +297,7 @@
 
     </footer>
 
-<script src="../../../src/js/vocabulary.js"></script>
+<script src="../../src/js/vocabulary.js"></script>
 
 </body>
 </html>

--- a/specimen/contexts/blog-index.html
+++ b/specimen/contexts/blog-index.html
@@ -548,16 +548,19 @@
     </div>
 
     <div class="subscribe">
-    <h2>Subscribe to our Newsletter</h2>
-    <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank" novalidate="">
-        <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required="">
-        <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-        <div style="position: absolute; left: -5000px" aria-hidden="true">
-          <input type="text" name="b_fd30364b6577b471373d6076c_4603fe102a" tabindex="-1" value="">
+        <h2>Subscribe to our Newsletter</h2>
+        <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank" novalidate="">
+            <div class="input-wrap">
+                <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required="">
+                <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+                <div style="position: absolute; left: -5000px" aria-hidden="true">
+                  <input type="text" name="b_fd30364b6577b471373d6076c_4603fe102a" tabindex="-1" value="">
+                </div>
+                <input type="submit" value="subscribe" id="mc-embedded-subscribe" class="button small">
+                </div>
+            <span id="emailFeedback" class="error-message"></span>
+        </form>
         </div>
-        <input type="submit" value="subscribe" id="mc-embedded-subscribe" class="button small">
-      </form>
-    </div>
 
     <div class="donate">
         <h2>Support Our Work</h2>

--- a/specimen/contexts/blog-post.html
+++ b/specimen/contexts/blog-post.html
@@ -304,16 +304,19 @@
     </div>
 
     <div class="subscribe">
-    <h2>Subscribe to our Newsletter</h2>
-    <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank" novalidate="">
-        <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required="">
-        <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-        <div style="position: absolute; left: -5000px" aria-hidden="true">
-          <input type="text" name="b_fd30364b6577b471373d6076c_4603fe102a" tabindex="-1" value="">
+        <h2>Subscribe to our Newsletter</h2>
+        <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank" novalidate="">
+            <div class="input-wrap">
+                <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required="">
+                <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+                <div style="position: absolute; left: -5000px" aria-hidden="true">
+                  <input type="text" name="b_fd30364b6577b471373d6076c_4603fe102a" tabindex="-1" value="">
+                </div>
+                <input type="submit" value="subscribe" id="mc-embedded-subscribe" class="button small">
+                </div>
+            <span id="emailFeedback" class="error-message"></span>
+        </form>
         </div>
-        <input type="submit" value="subscribe" id="mc-embedded-subscribe" class="button small">
-      </form>
-    </div>
 
     <div class="donate">
         <h2>Support Our Work</h2>

--- a/specimen/contexts/default-page.html
+++ b/specimen/contexts/default-page.html
@@ -236,15 +236,18 @@
     </div>
 
     <div class="subscribe">
-    <h2>Subscribe to our Newsletter</h2>
-    <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank" novalidate="">
-        <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required="">
-        <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-        <div style="position: absolute; left: -5000px" aria-hidden="true">
-          <input type="text" name="b_fd30364b6577b471373d6076c_4603fe102a" tabindex="-1" value="">
-        </div>
-        <input type="submit" value="subscribe" id="mc-embedded-subscribe" class="button small">
-      </form>
+        <h2>Subscribe to our Newsletter</h2>
+        <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank" novalidate="">
+            <div class="input-wrap">
+                <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required="">
+                <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+                <div style="position: absolute; left: -5000px" aria-hidden="true">
+                  <input type="text" name="b_fd30364b6577b471373d6076c_4603fe102a" tabindex="-1" value="">
+                </div>
+                <input type="submit" value="subscribe" id="mc-embedded-subscribe" class="button small">
+                </div>
+            <span id="emailFeedback" class="error-message"></span>
+        </form>
     </div>
 
     <div class="donate">

--- a/specimen/contexts/home-index.html
+++ b/specimen/contexts/home-index.html
@@ -410,15 +410,18 @@
     </div>
 
     <div class="subscribe">
-    <h2>Subscribe to our Newsletter</h2>
-    <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank" novalidate="">
-        <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required="">
-        <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-        <div style="position: absolute; left: -5000px" aria-hidden="true">
-          <input type="text" name="b_fd30364b6577b471373d6076c_4603fe102a" tabindex="-1" value="">
-        </div>
-        <input type="submit" value="subscribe" id="mc-embedded-subscribe" class="button small">
-      </form>
+        <h2>Subscribe to our Newsletter</h2>
+        <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank" novalidate="">
+            <div class="input-wrap">
+                <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required="">
+                <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+                <div style="position: absolute; left: -5000px" aria-hidden="true">
+                  <input type="text" name="b_fd30364b6577b471373d6076c_4603fe102a" tabindex="-1" value="">
+                </div>
+                <input type="submit" value="subscribe" id="mc-embedded-subscribe" class="button small">
+                </div>
+            <span id="emailFeedback" class="error-message"></span>
+        </form>
     </div>
 
     <div class="donate">

--- a/specimen/contexts/license-page.html
+++ b/specimen/contexts/license-page.html
@@ -139,15 +139,18 @@
     </div>
 
     <div class="subscribe">
-    <h2>Subscribe to our Newsletter</h2>
-    <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank" novalidate="">
-        <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required="">
-        <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-        <div style="position: absolute; left: -5000px" aria-hidden="true">
-          <input type="text" name="b_fd30364b6577b471373d6076c_4603fe102a" tabindex="-1" value="">
-        </div>
-        <input type="submit" value="subscribe" id="mc-embedded-subscribe" class="button small">
-      </form>
+        <h2>Subscribe to our Newsletter</h2>
+        <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank" novalidate="">
+            <div class="input-wrap">
+                <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required="">
+                <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+                <div style="position: absolute; left: -5000px" aria-hidden="true">
+                  <input type="text" name="b_fd30364b6577b471373d6076c_4603fe102a" tabindex="-1" value="">
+                </div>
+                <input type="submit" value="subscribe" id="mc-embedded-subscribe" class="button small">
+                </div>
+            <span id="emailFeedback" class="error-message"></span>
+        </form>
     </div>
 
     <div class="donate">

--- a/specimen/contexts/person-page.html
+++ b/specimen/contexts/person-page.html
@@ -233,15 +233,18 @@
     </div>
 
     <div class="subscribe">
-    <h2>Subscribe to our Newsletter</h2>
-    <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank" novalidate="">
-        <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required="">
-        <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-        <div style="position: absolute; left: -5000px" aria-hidden="true">
-          <input type="text" name="b_fd30364b6577b471373d6076c_4603fe102a" tabindex="-1" value="">
-        </div>
-        <input type="submit" value="subscribe" id="mc-embedded-subscribe" class="button small">
-      </form>
+        <h2>Subscribe to our Newsletter</h2>
+        <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank" novalidate="">
+            <div class="input-wrap">
+                <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required="">
+                <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+                <div style="position: absolute; left: -5000px" aria-hidden="true">
+                  <input type="text" name="b_fd30364b6577b471373d6076c_4603fe102a" tabindex="-1" value="">
+                </div>
+                <input type="submit" value="subscribe" id="mc-embedded-subscribe" class="button small">
+                </div>
+            <span id="emailFeedback" class="error-message"></span>
+        </form>
     </div>
 
     <div class="donate">

--- a/specimen/contexts/program-index.html
+++ b/specimen/contexts/program-index.html
@@ -238,15 +238,18 @@
     </div>
 
     <div class="subscribe">
-    <h2>Subscribe to our Newsletter</h2>
-    <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank" novalidate="">
-        <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required="">
-        <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-        <div style="position: absolute; left: -5000px" aria-hidden="true">
-          <input type="text" name="b_fd30364b6577b471373d6076c_4603fe102a" tabindex="-1" value="">
-        </div>
-        <input type="submit" value="subscribe" id="mc-embedded-subscribe" class="button small">
-      </form>
+        <h2>Subscribe to our Newsletter</h2>
+        <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank" novalidate="">
+            <div class="input-wrap">
+                <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required="">
+                <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+                <div style="position: absolute; left: -5000px" aria-hidden="true">
+                  <input type="text" name="b_fd30364b6577b471373d6076c_4603fe102a" tabindex="-1" value="">
+                </div>
+                <input type="submit" value="subscribe" id="mc-embedded-subscribe" class="button small">
+                </div>
+            <span id="emailFeedback" class="error-message"></span>
+        </form>
     </div>
 
     <div class="donate">

--- a/specimen/contexts/program-page.html
+++ b/specimen/contexts/program-page.html
@@ -217,15 +217,18 @@
     </div>
 
     <div class="subscribe">
-    <h2>Subscribe to our Newsletter</h2>
-    <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank" novalidate="">
-        <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required="">
-        <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-        <div style="position: absolute; left: -5000px" aria-hidden="true">
-          <input type="text" name="b_fd30364b6577b471373d6076c_4603fe102a" tabindex="-1" value="">
-        </div>
-        <input type="submit" value="subscribe" id="mc-embedded-subscribe" class="button small">
-      </form>
+        <h2>Subscribe to our Newsletter</h2>
+        <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank" novalidate="">
+            <div class="input-wrap">
+                <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required="">
+                <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+                <div style="position: absolute; left: -5000px" aria-hidden="true">
+                  <input type="text" name="b_fd30364b6577b471373d6076c_4603fe102a" tabindex="-1" value="">
+                </div>
+                <input type="submit" value="subscribe" id="mc-embedded-subscribe" class="button small">
+                </div>
+            <span id="emailFeedback" class="error-message"></span>
+        </form>
     </div>
 
     <div class="donate">

--- a/specimen/contexts/search-index.html
+++ b/specimen/contexts/search-index.html
@@ -256,15 +256,18 @@
     </div>
 
     <div class="subscribe">
-    <h2>Subscribe to our Newsletter</h2>
-    <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank" novalidate="">
-        <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required="">
-        <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-        <div style="position: absolute; left: -5000px" aria-hidden="true">
-          <input type="text" name="b_fd30364b6577b471373d6076c_4603fe102a" tabindex="-1" value="">
-        </div>
-        <input type="submit" value="subscribe" id="mc-embedded-subscribe" class="button small">
-      </form>
+        <h2>Subscribe to our Newsletter</h2>
+        <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank" novalidate="">
+            <div class="input-wrap">
+                <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required="">
+                <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+                <div style="position: absolute; left: -5000px" aria-hidden="true">
+                  <input type="text" name="b_fd30364b6577b471373d6076c_4603fe102a" tabindex="-1" value="">
+                </div>
+                <input type="submit" value="subscribe" id="mc-embedded-subscribe" class="button small">
+                </div>
+            <span id="emailFeedback" class="error-message"></span>
+        </form>
     </div>
 
     <div class="donate">

--- a/specimen/contexts/team-index.html
+++ b/specimen/contexts/team-index.html
@@ -191,15 +191,18 @@
     </div>
 
     <div class="subscribe">
-    <h2>Subscribe to our Newsletter</h2>
-    <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank" novalidate="">
-        <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required="">
-        <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-        <div style="position: absolute; left: -5000px" aria-hidden="true">
-          <input type="text" name="b_fd30364b6577b471373d6076c_4603fe102a" tabindex="-1" value="">
-        </div>
-        <input type="submit" value="subscribe" id="mc-embedded-subscribe" class="button small">
-      </form>
+        <h2>Subscribe to our Newsletter</h2>
+        <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank" novalidate="">
+            <div class="input-wrap">
+                <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required="">
+                <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+                <div style="position: absolute; left: -5000px" aria-hidden="true">
+                  <input type="text" name="b_fd30364b6577b471373d6076c_4603fe102a" tabindex="-1" value="">
+                </div>
+                <input type="submit" value="subscribe" id="mc-embedded-subscribe" class="button small">
+                </div>
+            <span id="emailFeedback" class="error-message"></span>
+        </form>
     </div>
 
     <div class="donate">

--- a/specimen/contexts/walkthrough-page.html
+++ b/specimen/contexts/walkthrough-page.html
@@ -147,15 +147,18 @@
     </div>
 
     <div class="subscribe">
-    <h2>Subscribe to our Newsletter</h2>
-    <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank" novalidate="">
-        <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required="">
-        <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-        <div style="position: absolute; left: -5000px" aria-hidden="true">
-          <input type="text" name="b_fd30364b6577b471373d6076c_4603fe102a" tabindex="-1" value="">
-        </div>
-        <input type="submit" value="subscribe" id="mc-embedded-subscribe" class="button small">
-      </form>
+        <h2>Subscribe to our Newsletter</h2>
+        <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank" novalidate="">
+            <div class="input-wrap">
+                <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required="">
+                <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+                <div style="position: absolute; left: -5000px" aria-hidden="true">
+                  <input type="text" name="b_fd30364b6577b471373d6076c_4603fe102a" tabindex="-1" value="">
+                </div>
+                <input type="submit" value="subscribe" id="mc-embedded-subscribe" class="button small">
+                </div>
+            <span id="emailFeedback" class="error-message"></span>
+        </form>
     </div>
 
     <div class="donate">

--- a/src/css/vocabulary.css
+++ b/src/css/vocabulary.css
@@ -1407,6 +1407,39 @@ body > footer .subscribe form input.button {
     color: rgb(255, 255, 255);
 }
 
+input:focus {
+    outline: none; /* Remove default focus outline */
+}
+
+.input.invalid {
+    border-color: red;
+}
+
+.input.valid {
+    border-color: green;
+}
+
+.input-wrap {
+    display: flex; 
+    align-items: center; 
+}
+
+.email {
+    flex-grow: 1; 
+    margin-right: 0px; 
+}
+
+.error-message {
+    font-size: 12px; 
+    color: red; 
+    margin-top: 10px; 
+    display: block; 
+}
+.subscribe form {
+    display: flex;
+    flex-direction: column;
+}
+
 body > footer .donate {
     grid-area: donate;
 }

--- a/src/js/vocabulary.js
+++ b/src/js/vocabulary.js
@@ -30,3 +30,22 @@ if (attributionButton !== null && attributionPanel !== null ) {
     });
 
 }
+
+document.addEventListener('DOMContentLoaded', function () {
+    const emailInput = document.getElementById('mce-EMAIL');
+    const feedbackElement = document.getElementById('emailFeedback');
+    emailInput.addEventListener('input', validateEmailInput);
+    function validateEmailInput() {
+        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    
+        if (emailRegex.test(emailInput.value)) {
+            feedbackElement.textContent = ""; // 
+            emailInput.classList.remove('invalid'); // Removes invalid class
+            emailInput.classList.add('valid'); // Adds valid class
+        } else {
+            feedbackElement.textContent = "Please provide a valid email"; // Show error message
+            emailInput.classList.remove('valid'); // Removes valid class
+            emailInput.classList.add('invalid'); // Adds invalid class
+        }
+    }
+  });  


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'.  -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
<!-- Replace [issue number] with the issue number (don't leave the square brackets)--likewise for [issue author]. -->
- Fixes #121 by @possumbilities 

## Description
<!-- Concisely describe what the pull request does. -->
I added email input validation to ensure users enter a valid email format. Users receive immediate feedback below the input field, with color-coded borders indicating whether their entry is valid (green) or invalid (red). Also, I added it to all the HTML files under the context folder so that all the footers would have this feature.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->
It uses regular expression to check the email format
it uses HTML, CSS and Js

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or comment out this section entirely. -->

## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [ ] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main` or `master`).
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
