### PR TITLE
[Fix] Fixes responsiveness issues for related posts section of prgram-index.html

### DIFF
--- a/src/css/vocabulary.css
+++ b/src/css/vocabulary.css
@@ -1856,6 +1856,10 @@ body > footer .license svg {
         display: flex;
         flex-wrap: wrap;
     }
+
+    main article.posts.related ul {
+        grid-template-columns: 1fr 1fr;
+    }
 }
 
 @media (max-width: 705px) {
@@ -2022,6 +2026,10 @@ body > footer .license svg {
 
     body > footer .footer-menu ul {
         display: block;
+    }
+
+    main article.posts.related ul {
+        grid-template-columns: 1fr;
     }
 }
 


### PR DESCRIPTION

## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'.  -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
<!-- Replace [issue number] with the issue number (don't leave the square brackets)--likewise for [issue author]. -->
- Fixes #110  by @Arinzelight

## Description
<!-- Concisely describe what the pull request does. -->
This pull request resolves the issue where the related posts section in `program-index.html` was not displaying properly on mobile devices. The layout was not responsive, causing elements to overflow on smaller screens.


## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->
- Adjusted the value of the grid-template-columns property  based on the screen size

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or comment out this section entirely. -->
1. Fork and clone the local repository to your local machine
2. Open the `program-index.html` file in your preferred browser
3. Using the dev tools of your browser, adjust the screen size all the way down to 320px
4. Perform visual inspection to ensure that the elements are not overflowing the viewport horizontally.

## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->
![Screenshot 2024-10-10 221350](https://github.com/user-attachments/assets/ab1e0fbd-b667-455a-99f7-c9bf7a6a714c)
![Screenshot 2024-10-10 221405](https://github.com/user-attachments/assets/5395551c-920f-4e72-af15-59f4c7f71f86)
![Screenshot 2024-10-10 221429](https://github.com/user-attachments/assets/97a2f210-675e-44d9-b321-c922b69459b4)


## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [ ] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
