### PR TITLE
Added Null Checks in vocabulary.js

### DIFF
--- a/src/js/vocabulary.js
+++ b/src/js/vocabulary.js
@@ -2,20 +2,25 @@ const exploreButton = document.querySelector('button.explore');
 const explorePanel = document.querySelector('.explore-panel');
 
 // explorePanel.classList.add('hide');
+if(exploreButton!==null && explorePanel!==null){
+    exploreButton.addEventListener('click', (event) => {
+        explorePanel.classList.toggle('expand');
+        // explorePanel.classList.toggle('hide');
+    });
+}
 
-exploreButton.addEventListener('click', (event) => {
-    explorePanel.classList.toggle('expand');
-    // explorePanel.classList.toggle('hide');
-});
 
 
 const menuButton = document.querySelector('button.expand-menu');
 const menuPanel = document.querySelector('.primary-menu');
 
-menuButton.addEventListener('click', (event) => {
-    menuPanel.classList.toggle('expand');
-    // explorePanel.classList.toggle('hide');
-});
+if(menuButton !== null && menuPanel !== null){
+    menuButton.addEventListener('click', (event) => {
+        menuPanel.classList.toggle('expand');
+        // explorePanel.classList.toggle('hide');
+    });
+}
+
 
 
 const attributionButton = document.querySelector('button.expand-attribution');

--- a/src/js/vocabulary.js
+++ b/src/js/vocabulary.js
@@ -2,7 +2,7 @@ const exploreButton = document.querySelector('button.explore');
 const explorePanel = document.querySelector('.explore-panel');
 
 // explorePanel.classList.add('hide');
-if(exploreButton!==null && explorePanel!==null){
+if(exploreButton!==null && explorePanel!==null) {
     exploreButton.addEventListener('click', (event) => {
         explorePanel.classList.toggle('expand');
         // explorePanel.classList.toggle('hide');
@@ -14,7 +14,7 @@ if(exploreButton!==null && explorePanel!==null){
 const menuButton = document.querySelector('button.expand-menu');
 const menuPanel = document.querySelector('.primary-menu');
 
-if(menuButton !== null && menuPanel !== null){
+if(menuButton !== null && menuPanel !== null) {
     menuButton.addEventListener('click', (event) => {
         menuPanel.classList.toggle('expand');
         // explorePanel.classList.toggle('hide');


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'.  -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
<!-- Replace [issue number] with the issue number (don't leave the square brackets)--likewise for [issue author]. -->
- Fixes #199 by @shivam8112005

## Description
The current code that handles button clicks for expanding panels (exploreButton, explorePanel, menuButton, menuPanel) is missing null checks. Although there are null checks in place for the attributionButton and attributionPanel, the same checks are not implemented for other buttons and panels. This could lead to errors if these elements are not present in the DOM.

## Technical details
This PR addresses the issue of missing null checks in the JavaScript code that manages various UI elements such as the explore panel, menu panel, and attribution panel. The updates ensure that event listeners are only attached when the corresponding elements are present in the DOM, improving the robustness of the code.

## Tests
1. Open the web application in a browser.
2. Open the developer console (F12).
3. Ensure there are no errors related to null or undefined when clicking on the explore, menu, or attribution buttons.

<!-- ## Screenshots -->
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the *default* branch of the repository (`main` or `master`).
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
