### PR TITLE
BugFix: Made search-index.html page responsive for mobile.

### DIFF
--- a/src/css/vocabulary.css
+++ b/src/css/vocabulary.css
@@ -95,6 +95,7 @@ a.more {
 /* post component - plural */
 
 .posts {
+    padding: 0 2rem;
     text-align: center;
 }
 
@@ -219,7 +220,7 @@ main {
 }
 
 main > * {
-    grid-column: 5 / span 3;
+    grid-column: 5 / span 3 !important;
 }
 
 main > header {
@@ -1556,7 +1557,10 @@ body > footer .license svg {
 }
 
 /* search-index context */
-
+.search-form{
+    padding: 0 2rem;
+    box-sizing: border-box;
+}
 .search-index main > header { /* generalize? */
     display: block;
     padding: 3.7em 0;
@@ -1588,7 +1592,8 @@ body > footer .license svg {
 }
 
 .search-index .search-form form button {
-    width: 10%;
+    width: fit-content;
+    padding: 0.2rem 1rem;
 
     cursor: pointer;
     background: black;
@@ -1828,9 +1833,9 @@ body > footer .license svg {
         grid-column: 3 / 10;
     }
 
-    .search-index main > header:before {
+    /* .search-index main > header:before {
         left: -9.3%;
-    }
+    } */
 }
 
 @media (max-width: 900px) {
@@ -1952,7 +1957,7 @@ body > footer .license svg {
     }
 
     main > header:before {
-        left: 0;
+        left: 0 !important;
     }
 
     .posts article figure {


### PR DESCRIPTION
## Fixes

- Fixes #142 by @wendy640

## Description
This PR resolves the responsiveness issues for smaller devices  in the search-index.html page . 
There are issues related to padding in posts section and overflowing of search-form in smaller devices . I have attempted to fix these issues through this PR.

## Technical details
1.Made changes to the  style rules defined in vocabulary.css file . 
2.More specifically, layout changes have been made to the search section & posts section of the page.

## Tests
1. Open the _search-index.html_ file.
2. Right-click and select **Inspect** (or press Ctrl+Shift+I / Cmd+Option+I on Mac).
3. Click **Toggle Device Toolbar** (or press Ctrl+Shift+M / Cmd+Shift+M on Mac ).
4. Test with different devices or adjust the viewport sizes.

## Screenshots
<img width="287" alt="Screenshot 2024-10-17 at 8 06 07 PM" src="https://github.com/user-attachments/assets/f14f1ae6-332b-4a82-a006-ccf5862c77b8">


## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
