### PR TITLE
Issue #241 fix - update documentation to reflect changes in footer.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1022,7 +1022,13 @@ This enables two modes of build work.
 
 <script>
 //escapes html within code elements
-document.querySelectorAll("code.lang-html").forEach(el => el.innerText = el.innerHTML);
+document.querySelectorAll("code.lang-html").forEach(el => {
+  let htmlContent = el.innerHTML
+
+  htmlContent = htmlContent.replace(/\s*required=""/g, " required");
+
+  el.innerText = htmlContent;
+});
 </script>
 
 </body>


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'.  -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
<!-- Replace [issue number] with the issue number (don't leave the square brackets)--likewise for [issue author]. -->
- Fixes #241 by @Queen-codes

## Description
<!-- Concisely describe what the pull request does. -->
This PR addresses the issue of `required=""` attributes being automatically rendered inside HTML code snippets on the documentation page. The solution ensures that the required attribute is consistently displayed as required (without the empty string) within HTML snippets for teaching and documentation purposes.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->
- The script uses a regular expression to identify and modify the `required=""` attributes within the `code.lang-html` blocks.
- The approach ensures that the required attribute remains visible in its correct form (required) without being removed or misrepresented in the code snippets.
- This change **only** affects the visual representation within the documentation, leaving the actual HTML structure untouched for non-snippet content.

## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

![SS](https://github.com/user-attachments/assets/11b85899-57d9-4b6e-948c-3255f19588f8)

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
