### PR TITLE
feat: Add link to CC Vocabulary Web Fonts as

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -107,9 +107,21 @@ This enables two modes of build work.
 
 <h3>01. Get the Vocabulary Files</h3>
 
-<p>Download the <a href="https://github.com/creativecommons/vocabulary">creativecommons/vocabulary</a> repository, rename the <span class="distinct">/src</span> directory to <span class="distinct">/vocabulary</span>, and move it into desired location.</p>
+<p>
+  Download the <a href="https://github.com/creativecommons/vocabulary">creativecommons/vocabulary</a> repository, 
+  rename the <span class="distinct">/src</span> directory to <span class="distinct">/vocabulary</span>, 
+  and move it into the desired location.
+</p>
 
-<p>Vocabulary needs to be included via CSS <strong>and</strong> JavaScript routes. Both are generally required, and recommended.</p>
+<p>
+  Alternatively, if you prefer an easier way to embed icons and badges on your website, 
+  consider using <a href="https://cc-vocabulary.netlify.app/" target="_blank">CC Vocabulary Web Fonts</a>. 
+  It provides a web-friendly solution for embedding vector graphics with minimal setup.
+</p>
+
+<p>
+  Vocabulary needs to be included via CSS <strong>and</strong> JavaScript routes. Both are generally required, and recommended.
+</p>
 
 <h3>02. CSS Installation</h3>
 

--- a/specimen/contexts/default-page.html
+++ b/specimen/contexts/default-page.html
@@ -54,7 +54,7 @@
         <ul>
             <li>
                 <a href="#">Global Network</a>
-                <p>Join a  global community working to strengthen the Commons</p>
+                <p>Join a global community working to strengthen the Commons</p>
             </li>
             <li>
                 <a href="#">Certificate</a>

--- a/src/js/vocabulary.js
+++ b/src/js/vocabulary.js
@@ -1,37 +1,34 @@
-const exploreButton = document.querySelector('button.explore');
-const explorePanel = document.querySelector('.explore-panel');
-
-// explorePanel.classList.add('hide');
-if(exploreButton!==null && explorePanel!==null) {
-    exploreButton.addEventListener('click', (event) => {
-        explorePanel.classList.toggle('expand');
-        // explorePanel.classList.toggle('hide');
+// Utility function to toggle panel and button state
+const toggleButtonState = (button, panel, expandedClass, activeText, inactiveText) => {
+    button.addEventListener('click', () => {
+      const isActive = button.classList.toggle('active'); // Toggle 'active' class on button
+      panel.classList.toggle(expandedClass); // Toggle the 'expanded' class on panel
+  
+      // Update button text based on the state
+      button.textContent = isActive ? activeText : inactiveText;
     });
-}
-
-
-
-const menuButton = document.querySelector('button.expand-menu');
-const menuPanel = document.querySelector('.primary-menu');
-
-if(menuButton !== null && menuPanel !== null) {
-    menuButton.addEventListener('click', (event) => {
-        menuPanel.classList.toggle('expand');
-        // explorePanel.classList.toggle('hide');
-    });
-}
-
-
-
-const attributionButton = document.querySelector('button.expand-attribution');
-const attributionPanel = document.querySelector('.attribution-panel');
-
-if (attributionButton !== null && attributionPanel !== null ) {
-
-    attributionButton.addEventListener('click', (event) => {
-        attributionButton.classList.toggle('selected');
-        attributionPanel.classList.toggle('expand');
-        // explorePanel.classList.toggle('hide');
-    });
-
-}
+  };
+  
+  // Element selectors
+  const selectElement = (selector) => document.querySelector(selector);
+  
+  // Initialize elements
+  const exploreButton = selectElement('button.explore');
+  const explorePanel = selectElement('.explore-panel');
+  const menuButton = selectElement('button.expand-menu');
+  const menuPanel = selectElement('.primary-menu');
+  const attributionButton = selectElement('button.expand-attribution');
+  const attributionPanel = selectElement('.attribution-panel');
+  
+  // Set up event listeners only if elements exist
+  exploreButton && exploreButton.addEventListener('click', () => {
+    explorePanel.classList.toggle('expanded');
+  });
+  
+  menuButton && menuButton.addEventListener('click', () => {
+    menuPanel.classList.toggle('expanded');
+  });
+  
+  attributionButton && attributionPanel &&
+    toggleButtonState(attributionButton, attributionPanel, 'expanded', 'Close', 'View');
+  


### PR DESCRIPTION
an alternative on the Installation section

- Added a link to the Vocabulary web fonts as
a simpler way to embed icons
- Placed the new paragraph in the Installation
section under "Get the Vocabulary Files"
- Helps users avoid the complexity of downloading
 and managing individual SVG assets
