### PR TITLE
Mobile Responsiveness issue in the program-index.html

### DIFF
--- a/src/css/vocabulary.css
+++ b/src/css/vocabulary.css
@@ -1987,6 +1987,9 @@ body > footer .license svg {
     main nav.pagination ol li {
         line-height: 250%;
     }
+    main article.posts.related ul {
+        grid-template-columns: 1fr 1fr;
+    }
 }
 
 @media (max-width: 580px) {


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'.  -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
<!-- Replace [issue number] with the issue number (don't leave the square brackets)--likewise for [issue author]. -->
- Fixes #110  by @Arinzelight

## Description
<!-- Concisely describe what the pull request does. -->
This PR resolves the layout issue in the related posts section of program-index.html, which was not displaying properly on mobile devices. The layout caused elements to overflow due to improper responsiveness. The issue has been fixed by modifying the CSS grid settings.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->
The problem was resolved by adjusting the grid template of the main article.posts.related ul element.

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or comment out this section entirely. -->
To verify this fix:

1. Open program-index.html on a mobile device or in a responsive design tool (such as Chrome DevTools).
2. Scroll to the related posts section.
3. Ensure the elements are now displayed properly in a responsive grid layout and stack as expected for smaller screen sizes.

## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->
![Screenshot 2024-10-20 005603](https://github.com/user-attachments/assets/a448ce35-2b25-4b82-90ba-f435fe428844)
![Screenshot 2024-10-20 005631](https://github.com/user-attachments/assets/04e20d4a-4856-4b67-8dcb-db25141d898e)
![Screenshot 2024-10-20 005644](https://github.com/user-attachments/assets/9a51b09e-ab49-4f4c-821e-7b3cb827fda8)


## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
