### PR TITLE
fix responsiveness issue within related posts on program-index.html

### DIFF
--- a/src/css/vocabulary.css
+++ b/src/css/vocabulary.css
@@ -1856,6 +1856,10 @@ body > footer .license svg {
         display: flex;
         flex-wrap: wrap;
     }
+
+    main article.posts.related ul {
+        grid-template-columns: 1fr  1fr;
+    }
 }
 
 @media (max-width: 705px) {
@@ -2022,6 +2026,10 @@ body > footer .license svg {
 
     body > footer .footer-menu ul {
         display: block;
+    }
+
+    main article.posts.related ul {
+        grid-template-columns: 1fr;
     }
 }
 


### PR DESCRIPTION
## Fixes

- Fixes  #110 by @Arinzelight [Ezinwa Arinze]

## Description
This pull request addresses the responsiveness issue in the related posts section of program-index.html. Previously, the layout was not adjusting properly on mobile devices, leading to element overflow. These CSS changes ensure that the layout is now responsive and elements stack properly on smaller screens.

## Technical details

Added media queries to adjust the grid layout based on screen width on vocabulary.css:
```
@media (max-width: 900px) {
  main article.posts.related ul {
    grid-template-columns: 1fr 1fr;
  }
}

@media (max-width: 580px) {
  main article.posts.related ul {
    grid-template-columns: 1fr;
  }
}
```

The layout will now display 2 post per row on screens up to 900px wide, and 1 posts per row on screens narrower than 580px.

## Tests

1. Open the program-index.html file on a mobile device or in a responsive design testing tool.
2. Scroll to the related posts section.
3. Confirm that elements now stack properly without overflowing.
4. Resize the screen to various widths to ensure the layout adjusts correctly, especially at 900px and 580px breakpoints.

## Screenshots
Before:
![program-page](https://github.com/user-attachments/assets/27748761-5ee5-4da4-806a-04ec75ad35d2)

After:
![medium](https://github.com/user-attachments/assets/187892eb-eeb8-4f22-9434-01bb29a74b0b)
![smaller](https://github.com/user-attachments/assets/8d19dd21-5105-41fa-9444-587148a9b5fa)


## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
