### PR TITLE
Link to Vocabulary from the Downloads page.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -107,9 +107,21 @@ This enables two modes of build work.
 
 <h3>01. Get the Vocabulary Files</h3>
 
-<p>Download the <a href="https://github.com/creativecommons/vocabulary">creativecommons/vocabulary</a> repository, rename the <span class="distinct">/src</span> directory to <span class="distinct">/vocabulary</span>, and move it into desired location.</p>
+<<p>
+  Download the <a href="https://github.com/creativecommons/vocabulary">creativecommons/vocabulary</a> repository, 
+  rename the <span class="distinct">/src</span> directory to <span class="distinct">/vocabulary</span>, 
+  and move it into the desired location.
+</p>
 
-<p>Vocabulary needs to be included via CSS <strong>and</strong> JavaScript routes. Both are generally required, and recommended.</p>
+<p>
+  Alternatively, if you prefer an easier way to embed icons and badges on your website, 
+  consider using <a href="https://cc-vocabulary.netlify.app/" target="_blank">CC Vocabulary Web Fonts</a>. 
+  It provides a web-friendly solution for embedding vector graphics with minimal setup.
+</p>
+
+<p>
+  Vocabulary needs to be included via CSS <strong>and</strong> JavaScript routes. Both are generally required, and recommended.
+</p>
 
 <h3>02. CSS Installation</h3>
 


### PR DESCRIPTION
fixes: [Link to Vocabulary from the Downloads page. #279](https://github.com/creativecommons/vocabulary/issues/56)]
Description:

This merge request aims to improve the discoverability of the Vocabulary resource by adding a direct link to it on the Downloads page. This will make it easier for users to access and download the Vocabulary resource, enhancing its visibility and usability.

Changes:

Add a link to Vocabulary: Include a clearly labeled link to the Vocabulary resource on the Downloads page. This link should be placed in a prominent location, such as the main navigation menu or a dedicated section for related resources.