### PR TITLE
fix: encode ampersand in docs/index.html to pass HTML validation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -47,7 +47,7 @@
 <p>Both projects are informed by the  <a href="https://creativecommons.org/wp-content/uploads/2019/10/Creative-Commons-Style-Guide-2019.pdf">CC Style Guide (2019)</a>, and incorporate or adapt its guidance into a digital context.</p>
 
 
-<h3>Structure & Behavior</h3>
+<h3>Structure &amp; Behavior</h3>
 
 <p>Vocabulary is raw material design system with inherent rules and generalized implementable documentation.</p>
 
@@ -194,7 +194,7 @@ This enables two modes of build work.
 
 <h3 id="global-header">Header - Global Area</h3><a class="permalink" href="#global-header">permalink</a>
 
-<p>Each CC site utilizing Vocabulary should include the global <span class="distinct">Header</span> & <span class="distinct">Footer</span> areas at the top and bottom of the site respectively.</p>
+<p>Each CC site utilizing Vocabulary should include the global <span class="distinct">Header</span> &amp; <span class="distinct">Footer</span> areas at the top and bottom of the site respectively.</p>
 
 <p>The Global Header component contains several sub-elements.</p>
 <ul>
@@ -310,7 +310,7 @@ This enables two modes of build work.
 
 <h3 id="global-footer">Footer - Global Area</h3><a class="permalink" href="#global-footer">permalink</a>
 
-<p>Each CC site utilizing Vocabulary should include the global <span class="distinct">Header</span> & <span class="distinct">Footer</span> areas at the top and bottom of the site respectively.</p>
+<p>Each CC site utilizing Vocabulary should include the global <span class="distinct">Header</span> &amp; <span class="distinct">Footer</span> areas at the top and bottom of the site respectively.</p>
 
 <p>The Global Footer component contains several sub-elements.</p>
 <ul>


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'.  -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
<!-- Replace [issue number] with the issue number (don't leave the square brackets)--likewise for [issue author]. -->
- Fixes #282  by @possumbilities 

## Description
<!-- Concisely describe what the pull request does. -->
This pull request addresses the HTML validation error in `docs/index.html` by encoding raw ampersands as `&amp;`. This ensures compliance with HTML standards and eliminates validation errors.
## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->
The raw ampersand characters on line 50, 197, 313 have been replaced with `&amp;` to ensure proper encoding. Validation checks were performed after the changes to confirm that no errors remain.

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or comment out this section entirely. -->

1. Run an HTML validation check using `html-validate` on `docs/index.html`.
2. Confirm that there are no validation errors reported.
## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x ] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x ] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x ] My commit messages follow [best practices][best_practices].
- [x ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
