### PR TITLE
Improved mobile responsiveness for search-index.html page

### DIFF
--- a/src/css/vocabulary.css
+++ b/src/css/vocabulary.css
@@ -1949,10 +1949,31 @@ body > footer .license svg {
     main > header:before {
         left: 0;
     }
+    .search-index main > header:before {
+        left: 0;
+    }
+
+    .search-index main > header {
+        padding: 3.7em 1em;
+    }
+    
+    .search-index .search-form form {
+        display: flex;
+        width: 100%;
+    }
+    
+    .search-index .search-form form button {
+        width: 20%;
+        border-top-right-radius: 4px;
+        border-bottom-right-radius: 4px;
+    }
 
     .posts article figure {
         width: 100%;
         flex: initial;
+    }
+    .posts .post{
+        margin: 0 var(--vocabulary-page-edges-space);
     }
 
     .team-index main > header {


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'.  -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
<!-- Replace [issue number] with the issue number (don't leave the square brackets)--likewise for [issue author]. -->
- Fixes #142  by @wendy640

## Description
<!-- Concisely describe what the pull request does. -->
This pull request improves the mobile responsiveness of the search-index.html page by addressing layout and styling issues affecting elements like post titles, text, and buttons. The fix ensures these elements adjust properly to smaller screens, enhancing readability and ease of interaction for mobile users.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->
The following changes were made:

1. Aligned the header and adjusted padding to improve layout.
2. Ensured the search form takes up the full width, with button styling adjusted for better fit and alignment.
3. Added consistent margins to post items for improved spacing.

These minimal CSS adjustments improve the page's responsiveness while maintaining clean and maintainable code.
## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or comment out this section entirely. -->
=>Open search-index.html on a mobile device or simulate a mobile viewport in Chrome DevTools.
=>Confirm the header, search form, and post items display correctly without overflow or misalignment.

## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->
Before:

![Screenshot 2024-10-26 181246](https://github.com/user-attachments/assets/a5462328-7bf7-477a-b9ea-1ca6a783135c)


![Screenshot 2024-10-26 181252](https://github.com/user-attachments/assets/b950c163-561e-4109-bcc0-9c36e5b5d3b8)


After:

![Screenshot 2024-10-26 181323](https://github.com/user-attachments/assets/21410316-62f3-40bf-acf9-f24d694ddc8e)


![Screenshot 2024-10-26 181329](https://github.com/user-attachments/assets/79bd76cd-557c-4c15-b1b8-1fb77e568083)


## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
