### PR TITLE
Fixes #283 [Lot of encoding errors on docs/index.html]

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2,10 +2,9 @@
 <html lang="en-US">
 <head>
 <title>Vocabulary - Docs</title>
-  
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
-<link rel="stylesheet" media="all" href="style.css" />
+<link rel="stylesheet" media="all" href="style.css">
 
 </head>
 <body>
@@ -82,7 +81,7 @@
 
 <h3>Upstream/Downstream Change Flow</h3>
 
-This enables two modes of build work. 
+This enables two modes of build work.
 
 <h4>A: upstream → downstream</h4>
 <ol>
@@ -121,9 +120,7 @@ This enables two modes of build work.
 
 <pre>
 <code class="lang-html">
-    
-<link rel="stylesheet" media="all" href="PATH/TO/style.css" />
-    
+<link rel="stylesheet" media="all" href="PATH/TO/style.css">
 </code>
 </pre>
 
@@ -131,15 +128,13 @@ This enables two modes of build work.
 
 <p>Include <span class="distinct">vocabulary.css</span> from within <span class="distinct">style.css</span> via a <a href="#">CSS @layer import</a> at the top of the file.</p>
 
-<aside> 
+<aside>
     <p>CSS Layers provide a reliable, and safely overridable cascade of rulesets.</p>
 </aside>
 
 <pre>
 <code class="lang-css">
-    
 @import 'PATH/TO/vocabulary/css/vocabulary.css' layer(vocabulary);
-    
 </code>
 </pre>
 
@@ -149,11 +144,8 @@ This enables two modes of build work.
 
 <pre>
 <code class="lang-css">
-    
 @import 'PATH/TO/vocabulary/css/vocabulary.css' layer(vocabulary);
 @import 'PATH/TO/vocabulary/css/vocabulary-tests.css' layer(vocabulary-tests);
-    
-    
 </code>
 </pre>
 
@@ -170,7 +162,6 @@ This enables two modes of build work.
 
 <script src="PATH/TO/vocabulary/js/vocabulary.js"></script>
 
-        
 </code>
 </pre>
 
@@ -198,7 +189,7 @@ This enables two modes of build work.
 
 <p>The Global Header component contains several sub-elements.</p>
 <ul>
-  
+
   <li>
     Masthead
     <ul>
@@ -206,7 +197,7 @@ This enables two modes of build work.
       <li>Primary Nav Menu</li>
       <li>Ancillary Nav Menu</li>
     </ul>
-  </li> 
+  </li>
   <li>
     Explore Panel (Explore CC)
     <ul>
@@ -300,7 +291,7 @@ This enables two modes of build work.
 
 </header>
 
-      
+
 </code>
 </pre>
 
@@ -348,7 +339,7 @@ This enables two modes of build work.
     <div class="contact">
     <!-- this area lacks a heading? -->
     <h2>Contact Us</h2>
-    <p>Creative Commons <br /> PO Box 1866, Mountain View, CA 94042</p>
+    <p>Creative Commons <br> PO Box 1866, Mountain View, CA 94042</p>
     <p><a href="mailto:info@creativecommons.org">info@creativecommons.org</a></p>
     <p><a href="tel:+14154296753">+1&#8209;415&#8209;429&#8209;6753</a></p>
 
@@ -395,7 +386,7 @@ This enables two modes of build work.
 
 </footer>
 
-      
+
 </code>
 </pre>
 
@@ -411,8 +402,8 @@ This enables two modes of build work.
  <!-- <li><span class="distinct">Main Content Region</span> of the <span class="distinct">Home Index</span></li>
   <li><span class="distinct">Main Content Region</span> of the <span class="distinct">Blog Archive</span></li> -->
 
-  <li><span class="distinct">body.home-index > main > article.authored-posts > footer > article.attribution-list</span>; on the <span class="distinct">home-index</span> page-level</li>
-  <li><span class="distinct">body.blog-index > main > article.attribution-list</span>; after referenced media; on the <span class="distinct">blog-index</span> page-level</li>
+  <li><span class="distinct">body.home-index &gt; main &gt; article.authored-posts &gt; footer &gt; article.attribution-list</span>; on the <span class="distinct">home-index</span> page-level</li>
+  <li><span class="distinct">body.blog-index &gt; main &gt; article.attribution-list</span>; after referenced media; on the <span class="distinct">blog-index</span> page-level</li>
 </ul>
 
 <pre>
@@ -426,7 +417,7 @@ This enables two modes of build work.
       <li>
         <article>
           <figure>
-            <img src="PATH/TO/image.png" />
+            <img src="PATH/TO/image.png" alt="">
             <span class="attribution">attribution here</span>
           </figure>
         </article>
@@ -447,15 +438,15 @@ This enables two modes of build work.
 
 <h4>Expected Contexts</h4>
 <ul>
-  <li><span class="distinct">body.* > article.attention</span>; after <span class="distinct">body > header</span>; before <span class="distinct">body > main</span>; all page-levels</li>
-  <li><span class="distinct">body.archive-page > aside > article.attention</span>; as last child item, only <span class="distinct">default-page</span>, <span class="distinct">archive-page</span> levels</li>
+  <li><span class="distinct">body.* &gt; article.attention</span>; after <span class="distinct">body &gt; header</span>; before <span class="distinct">body &gt; main</span>; all page-levels</li>
+  <li><span class="distinct">body.archive-page &gt; aside &gt; article.attention</span>; as last child item, only <span class="distinct">default-page</span>, <span class="distinct">archive-page</span> levels</li>
 </ul>
 
 <pre>
 <code class="lang-html">
 
   <article class="attention">
-  
+
    content here
 
   </article>
@@ -469,7 +460,7 @@ This enables two modes of build work.
 
 <h4>Expected Contexts</h4>
 <ul>
-  <li><span class="distinct">article.persons > ul > li > article.person</span> </li>
+  <li><span class="distinct">article.persons &gt; ul &gt; li &gt; article.person</span> </li>
 
 </ul>
 
@@ -480,7 +471,7 @@ This enables two modes of build work.
     <h3><a href="#">Name Here</a></h3>
     <span class="title">Position/Title here</span>
     <figure>
-      <img src="PATH/TO/profile.jpg" />
+      <img src="PATH/TO/profile.jpg" alt="">
     </figure>
     <p>Truncated bio here&hellip;</p>
   </article>
@@ -493,7 +484,7 @@ This enables two modes of build work.
 
 <h4>Expected Contexts</h4>
 <ul>
-  <li><span class="distinct">body.team-index main</span>, directly after <span class="distinct">main > header</span> </li>
+  <li><span class="distinct">body.team-index main</span>, directly after <span class="distinct">main &gt; header</span> </li>
 
 </ul>
 
@@ -508,7 +499,7 @@ This enables two modes of build work.
           <h3><a href="#">Name Here</a></h3>
           <span class="title">Position/Title here</span>
           <figure>
-            <img src="PATH/TO/profile.jpg" />
+            <img src="PATH/TO/profile.jpg" alt="">
           </figure>
           <p>Truncated bio here&hellip;</p>
          </article>
@@ -528,9 +519,9 @@ This enables two modes of build work.
 
 <h4>Expected Contexts</h4>
 <ul>
-  <li><span class="distinct">main > article.post</span> </li>
-  <li><span class="distinct">main > article.posts > article.post</span> </li>
-  <li><span class="distinct">article.posts  ul > li > article.post</span> </li>
+  <li><span class="distinct">main &gt; article.post</span> </li>
+  <li><span class="distinct">main &gt; article.posts &gt; article.post</span> </li>
+  <li><span class="distinct">article.posts  ul &gt; li &gt; article.post</span> </li>
 </ul>
 
 <pre>
@@ -545,7 +536,7 @@ This enables two modes of build work.
 
     </header>
     <figure>
-      <img src="PATH/TO/image.jpg" />
+      <img src="PATH/TO/image.jpg" alt="">
       <span class="attribution">attribution here</span>
     </figure>
     <p>truncated teaser excerpt </p>
@@ -562,12 +553,12 @@ This enables two modes of build work.
 <p><span class="distinct">Posts</span> components support a pseudo-semantic variant class of <span class="distinct">featured</span> or <span class="distinct">related</span>. This helps further describe what they are more specifically, but allows a semantic-ish target for their change in behavior or provided sub-elements. </p>
 <h4>Expected Contexts</h4>
 <ul>
-  <li><span class="distinct">main > article.posts</span>, directly after the <span class="distinct">main > header</span> </li>
-  <li><span class="distinct">body.blog-index > main > article.posts.featured</span>, directly after the <span class="distinct">main > header</span> </li>
-  <li><span class="distinct">body.blog-index > main > article.posts</span>, directly after the <span class="distinct">main > article.posts.featured</span> </li>
-  <li><span class="distinct">body.archive-page > main > article.posts</span>, directly after the <span class="distinct">main > aside</span>  </li>
-  <li><span class="distinct">body.person-page > main > article.posts</span>, directly after the <span class="distinct">main > header</span>  </li>
-  <li><span class="distinct">body.blog-post > main > article.posts.related</span>, as the last child of <span class="distinct">body > main</span> </li>
+  <li><span class="distinct">main &gt; article.posts</span>, directly after the <span class="distinct">main &gt; header</span> </li>
+  <li><span class="distinct">body.blog-index &gt; main &gt; article.posts.featured</span>, directly after the <span class="distinct">main &gt; header</span> </li>
+  <li><span class="distinct">body.blog-index &gt; main &gt; article.posts</span>, directly after the <span class="distinct">main &gt; article.posts.featured</span> </li>
+  <li><span class="distinct">body.archive-page &gt; main &gt; article.posts</span>, directly after the <span class="distinct">main &gt; aside</span>  </li>
+  <li><span class="distinct">body.person-page &gt; main &gt; article.posts</span>, directly after the <span class="distinct">main &gt; header</span>  </li>
+  <li><span class="distinct">body.blog-post &gt; main &gt; article.posts.related</span>, as the last child of <span class="distinct">body &gt; main</span> </li>
 
 </ul>
 
@@ -577,7 +568,7 @@ This enables two modes of build work.
   <article class="posts">
 
   <h2>Title Here</h2>
-  
+
     <article class="story">
       <header>
       <h3><a href="#">Title Here</a></h3>
@@ -587,7 +578,7 @@ This enables two modes of build work.
 
       </header>
       <figure>
-        <img src="PATH/TO/image.jpg" />
+        <img src="PATH/TO/image.jpg" alt="">
         <span class="attribution">attribution here</span>
       </figure>
       <p>truncated teaser excerpt </p>
@@ -612,9 +603,9 @@ This enables two modes of build work.
 
 <h4>Expected Contexts</h4>
 <ul>
-  <li><span class="distinct">body.archive-page > main > nav.pagination</span>, as the last child of <span class="distinct">body > main</span> </li>
-  <li><span class="distinct">body.person-page > main > nav.pagination</span>, as the last child of <span class="distinct">body > main</span> </li>
-  <li><span class="distinct">body.search-index > main > nav.pagination</span>, as the last child of <span class="distinct">body > main</span> </li>
+  <li><span class="distinct">body.archive-page &gt; main &gt; nav.pagination</span>, as the last child of <span class="distinct">body &gt; main</span> </li>
+  <li><span class="distinct">body.person-page &gt; main &gt; nav.pagination</span>, as the last child of <span class="distinct">body &gt; main</span> </li>
+  <li><span class="distinct">body.search-index &gt; main &gt; nav.pagination</span>, as the last child of <span class="distinct">body &gt; main</span> </li>
 
 </ul>
 
@@ -632,7 +623,7 @@ This enables two modes of build work.
         <li><a href="#">527</a></li>
 
         <!-- <li><a href="#"><</a></li> -->
-        <li><a href="#">></a></li>
+        <li><a href="#">&gt;</a></li>
     </ol>
 
   </nav>
@@ -646,7 +637,7 @@ This enables two modes of build work.
 
 <h4>Expected Contexts</h4>
 <ul>
-  <li><span class="distinct">body.blog-post > main > aside.opening</span>; optionally after <span class="distinct">main > header</span></li>
+  <li><span class="distinct">body.blog-post &gt; main &gt; aside.opening</span>; optionally after <span class="distinct">main &gt; header</span></li>
 
 
 </ul>
@@ -666,7 +657,7 @@ This enables two modes of build work.
 
 <h4>Expected Contexts</h4>
 <ul>
-  <li><span class="distinct">body.blog-post > main > aside.closing</span>; optionally before <span class="distinct">main > span.pub-date</span></li>
+  <li><span class="distinct">body.blog-post &gt; main &gt; aside.closing</span>; optionally before <span class="distinct">main &gt; span.pub-date</span></li>
 
 
 </ul>
@@ -686,7 +677,7 @@ This enables two modes of build work.
 
 <h4>Expected Contexts</h4>
 <ul>
-  <li><span class="distinct">body.blog-post > main > article.tags</span>; optionally after <span class="distinct">main > span.pubdate</span></li>
+  <li><span class="distinct">body.blog-post &gt; main &gt; article.tags</span>; optionally after <span class="distinct">main &gt; span.pubdate</span></li>
 
 
 </ul>
@@ -712,8 +703,8 @@ This enables two modes of build work.
 
 <h4>Expected Contexts</h4>
 <ul>
-  <li><span class="distinct">body > aside</span>; optionally after <span class="distinct">main > header</span></li>
-<li><span class="distinct">body.archive-page > aside</span>, after <span class="distinct">main > header</span></li>
+  <li><span class="distinct">body &gt; aside</span>; optionally after <span class="distinct">main &gt; header</span></li>
+<li><span class="distinct">body.archive-page &gt; aside</span>, after <span class="distinct">main &gt; header</span></li>
 
 
 </ul>
@@ -734,7 +725,7 @@ This enables two modes of build work.
 
 <h4>Expected Contexts</h4>
 <ul>
-<li><span class="distinct">body.archive-page > aside > nav.filter-menu</span></li>
+<li><span class="distinct">body.archive-page &gt; aside &gt; nav.filter-menu</span></li>
 
 </ul>
 
@@ -759,7 +750,7 @@ This enables two modes of build work.
 
 <h4>Expected Contexts</h4>
 <ul>
-<li><span class="distinct">body.archive-page > aside > nav</span></li>
+<li><span class="distinct">body.archive-page &gt; aside &gt; nav</span></li>
 
 </ul>
 
@@ -785,7 +776,7 @@ This enables two modes of build work.
 
 <h4>Expected Contexts</h4>
 <ul>
-<li><span class="distinct">article.case-studies > ul > li > article.data-point</span></li>
+<li><span class="distinct">article.case-studies &gt; ul &gt; li &gt; article.data-point</span></li>
 
 </ul>
 
@@ -798,7 +789,7 @@ This enables two modes of build work.
     <h3 class="stat">55+ million articles</h3>
     <p>Descriptive text here</p>
   </article>
- 
+
 
 </code>
 </pre>
@@ -810,7 +801,7 @@ This enables two modes of build work.
 
 <h4>Expected Contexts</h4>
 <ul>
-<li><span class="distinct">article.case-studies > footer > article.data-points</span></li>
+<li><span class="distinct">article.case-studies &gt; footer &gt; article.data-points</span></li>
 
 </ul>
 
@@ -842,7 +833,7 @@ This enables two modes of build work.
 
 <h4>Expected Contexts</h4>
 <ul>
-<li><span class="distinct">body.home-index > main > article.case-studies</span></li>
+<li><span class="distinct">body.home-index &gt; main &gt; article.case-studies</span></li>
 
 </ul>
 
@@ -855,7 +846,7 @@ This enables two modes of build work.
     <ul>
       <li>
         <figure>
-          <img src="PATH/TO/home.jpg" />
+          <img src="PATH/TO/home.jpg" alt="">
           <span class="attribution">attribution here</span>
          </figure>
        </li>
@@ -891,7 +882,7 @@ This enables two modes of build work.
 
 <h4>Expected Contexts</h4>
 <ul>
-<li><span class="distinct">body.search-index > main > header</span>; directly after the <span class="distinct">main > header > h1</span></li>
+<li><span class="distinct">body.search-index &gt; main &gt; header</span>; directly after the <span class="distinct">main &gt; header &gt; h1</span></li>
 
 </ul>
 
@@ -915,7 +906,7 @@ This enables two modes of build work.
 
 <h4>Expected Contexts</h4>
 <ul>
-<li><span class="distinct">body.home-index > main > article.topic-summary</span></li>
+<li><span class="distinct">body.home-index &gt; main &gt; article.topic-summary</span></li>
 
 </ul>
 
@@ -942,12 +933,12 @@ This enables two modes of build work.
 
 <h4>Expected Contexts</h4>
 <ul>
-<li><span class="distinct">body > main > header</span></li>
-<li><span class="distinct">body.archive-page > main > header</span></li>
-<li><span class="distinct">body.blog-index > main > header</span></li>
-<li><span class="distinct">body.blog-post > main > header</span></li>
-<li><span class="distinct">body.search-index > main > header</span></li>
-<li><span class="distinct">body.team-index > main > header</span></li>
+<li><span class="distinct">body &gt; main &gt; header</span></li>
+<li><span class="distinct">body.archive-page &gt; main &gt; header</span></li>
+<li><span class="distinct">body.blog-index &gt; main &gt; header</span></li>
+<li><span class="distinct">body.blog-post &gt; main &gt; header</span></li>
+<li><span class="distinct">body.search-index &gt; main &gt; header</span></li>
+<li><span class="distinct">body.team-index &gt; main &gt; header</span></li>
 </ul>
 
 <pre>
@@ -962,7 +953,7 @@ This enables two modes of build work.
     <span class="categories">  <!-- optional -->
       <a href="#">Open Culture</a>
     </span>
-  
+
   </header>
 
 </code>
@@ -973,7 +964,7 @@ This enables two modes of build work.
 
 <h4>Expected Contexts</h4>
 <ul>
-<li><span class="distinct">body.person-page > main > header</span></li>
+<li><span class="distinct">body.person-page &gt; main &gt; header</span></li>
 </ul>
 
 <pre>
@@ -986,13 +977,13 @@ This enables two modes of build work.
     <span class="pronouns">pronouns optionally here</span>
 
     <figure>
-      <img src="PATH/TO/profile.jpg" />
+      <img src="PATH/TO/profile.jpg" alt="">
       <span class="attribution">attribution here</span>
      </figure>
      <div class="bio">
        <p>Bio here</p>
      </div>
-  
+
   </header>
 
 </code>

--- a/docs/index.html
+++ b/docs/index.html
@@ -21,9 +21,9 @@
 
 </header>
 
-<aside class="menu">
+<aside class="menu" aria-label="Sidebar menu">
 
-<nav>
+<nav aria-label="Section navigation">
 <ul>
     <li><a href="#introduction" class="active">Introduction</a></li>
   <li><a href="#installation">Installation</a></li>
@@ -114,7 +114,7 @@ This enables two modes of build work.
 
 <p>Your project should include a “main/root” css styles file, which is included within the <span class="distinct">head</span> element of your HTML.</p>
 
-<aside>
+<aside aria-label="File naming recommendations">
     <p>It is recommended you call this file style.css; depending on the requirements of the system you could also call this file main.css, root.css, or manifest.css. WordPress Theme's, for example, require 'style.css'.</p>
 </aside>
 
@@ -128,7 +128,7 @@ This enables two modes of build work.
 
 <p>Include <span class="distinct">vocabulary.css</span> from within <span class="distinct">style.css</span> via a <a href="#">CSS @layer import</a> at the top of the file.</p>
 
-<aside>
+<aside aria-label="CSS Layers information">
     <p>CSS Layers provide a reliable, and safely overridable cascade of rulesets.</p>
 </aside>
 
@@ -175,7 +175,7 @@ This enables two modes of build work.
 
 <p><span class="distinct">Components</span> are discrete collected elements in a semantic order that provide a coherent meaning, and can be placed in various contexts which expect them. Various presentations and/or behaviors can then be applied to them depending on the needs, rules, and use cases of various contexts.</p>
 
-<aside>
+<aside aria-label="Naming conventions note">
 <p>There are perhaps better naming conventions than "components", but when used here it doesn't mean JS Components generally, Web Components, or React Components; it's just the term as general as possible.</p>
 </aside>
 
@@ -224,7 +224,7 @@ This enables two modes of build work.
     <div class="masthead">
       <h1><a class="identity-logo product" href="#">Vocabulary</a></h1>
         <button class="expand-menu">Menu</button>
-        <nav class="primary-menu">
+        <nav class="primary-menu" aria-label="Primary site navigation">
             <ul>
                 <li><a href="#">Who We Are</a></li>
                 <li><a href="#">What We Do</a></li>
@@ -235,7 +235,7 @@ This enables two modes of build work.
             </ul>
         </nav>
 
-        <nav class="ancillary-menu">
+        <nav class="ancillary-menu" aria-label="Secondary site navigation">
             <ul>
                 <!-- uncomment below line, if translation functionality is present on site -->
                 <!-- <li><button class="locale icon-attach fa-globe">English</button></li> -->
@@ -252,13 +252,13 @@ This enables two modes of build work.
     <div class="explore-panel">
 
     <!-- (optional main CC logo, p, link on non-home site back to main site) -->
-    <aside>
+    <aside aria-label="Creative Commons support message">
         <a class="identity-logo" href="https://creativecommons.org">Creative Commons</a>
         <h2>Our Work Relies On You!</h2>
         <p>Help us keep the internet free and open.</p>
     </aside>
 
-    <nav class="explore-menu">
+    <nav class="explore-menu" aria-label="Explore Creative Commons resources">
         <ul>
             <li>
                 <a href="https://network.creativecommons.org/" target="_blank">Global Network</a>
@@ -326,7 +326,7 @@ This enables two modes of build work.
 <footer>
     <a class="identity-logo" href="#">Creative Commons</a>
 
-    <nav class="footer-menu">
+    <nav class="footer-menu" aria-label="Footer menu">
         <ul>
             <li><a href="/about/contact">Contact</a></li>
             <li><a href="https://mail.creativecommons.org/subscribe" target="_blank">Newsletter</a></li>
@@ -343,7 +343,7 @@ This enables two modes of build work.
     <p><a href="mailto:info@creativecommons.org">info@creativecommons.org</a></p>
     <p><a href="tel:+14154296753">+1&#8209;415&#8209;429&#8209;6753</a></p>
 
-    <nav class="social-menu">
+    <nav class="social-menu" aria-label="Social media links">
         <ul>
             <!-- <li><a class="icon-replace fa-instagram" href="#">Instagram</a></li> -->
             <li><a class="icon-replace fa-twitter" href="https://twitter.com/creativecommons" target="_blank">Twitter</a></li>
@@ -612,7 +612,7 @@ This enables two modes of build work.
 <pre>
 <code class="lang-html">
 
-  <nav class="pagination">
+  <nav class="pagination" aria-label="navigation of different pages">
     <ol>
         <li class="current"><a href="#">1</a></li>
         <li><a href="#">2</a></li>
@@ -645,7 +645,7 @@ This enables two modes of build work.
 <pre>
 <code class="lang-html">
 
-  <aside class="opening">
+  <aside class="opening" aria-label="Opening content">
     <p>content here</p>
   </aside>
 
@@ -665,7 +665,7 @@ This enables two modes of build work.
 <pre>
 <code class="lang-html">
 
-  <aside class="closing">
+  <aside class="closing" aria-label="ending content">
     <p>content here</p>
   </aside>
 
@@ -712,7 +712,7 @@ This enables two modes of build work.
 <pre>
 <code class="lang-html">
 
-  <aside>
+  <aside aria-label="Related information">
 
     contents here
 
@@ -732,7 +732,7 @@ This enables two modes of build work.
 <pre>
 <code class="lang-html">
 
-  <nav class="filter-menu">
+  <nav class="filter-menu" aria-label="Categories navigation">
        <h2>Categories</h2>
        <ul>
            <li><a href="#">All posts</a></li>
@@ -757,7 +757,7 @@ This enables two modes of build work.
 <pre>
 <code class="lang-html">
 
-  <nav>
+  <nav aria-label="Related Links navigation">
        <h2>Related Links</h2>
        <ul>
            <li><a href="#">All posts</a></li>


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'.  -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
<!-- Replace [issue number] with the issue number (don't leave the square brackets)--likewise for [issue author]. -->
- Fixes #283 by @OmarAmeen01

## Description
<!-- Concisely describe what the pull request does. -->
This PR addresses several HTML validation issues found in docs/index.html, including encoding errors, missing required attributes, and improper tag usage. The following changes have been made:

1. Encoding Errors:  Fixed instances where raw characters like > were not encoded as `&gt;`

2. Self-closing Tags:  Updated `<img />` and `<link />` elements to proper non-self-closing tags.

3. Missing alt Attributes:  Added missing alt attributes to `<img>` tags for accessibility.

4. Trailing Whitespace:  Removed trailing whitespace from several lines to maintain clean formatting.

5. Landmark Accessibility:  Added missing aria-label attributes to landmark elements for better accessibility.

6. Ignored Errors:  The issue regarding `<article>`, `<aside>`, `<nav>`, and `<header>` elements being used inside `<code>` tags is intentional and will be ignored.

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or comment out this section entirely. -->
1. Visual Check: Manually inspected docs/index.html to verify proper rendering of the file and ensure there are no visual regressions.
2. Accessibility: Used an accessibility checker to verify that all landmark elements have the correct aria-label attributes and that all `<img>` tags now have alt attributes.
3. HTML Validation: Ran html-validate on docs/index.html to confirm the encoding issues, self-closing tag issues, and trailing whitespace issues were resolved.

## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->
 only errors related to " element is not permitted as content under `<code>` " due to `<article>`, `<aside>`, `<nav>`, and `<header>` elements being used inside `<code>` tags.
![image](https://github.com/user-attachments/assets/b37756c7-c994-4ce5-9be3-0caad3d9e144)


## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
