### PR TITLE
consistently use single quotes in CSS files

### DIFF
--- a/src/css/library-vars.css
+++ b/src/css/library-vars.css
@@ -2,7 +2,7 @@
 
 /* brand typsetting */
 @font-face {
-    font-family:"Roboto Condensed";
+    font-family:'Roboto Condensed';
     font-style: normal;
     font-weight: 400;
     font-display: swap;
@@ -12,7 +12,7 @@
 }
 
 @font-face {
-    font-family:"Roboto Condensed";
+    font-family:'Roboto Condensed';
     font-style: normal;
     font-weight: 700;
     font-display: swap;
@@ -22,41 +22,41 @@
 }
 
 @font-face {
-    font-family: "Source Sans Pro";
+    font-family: 'Source Sans Pro';
     font-style: normal;
     font-weight: 400;
     font-display: swap;
-    src: url('../fonts/SourceSansPro-Regular.woff2') format("woff2"),
-        url('../fonts/SourceSansPro-Regular.woff') format("woff"),
-        url('../fonts/SourceSansPro-Regular.otf') format("opentype");
+    src: url('../fonts/SourceSansPro-Regular.woff2') format('woff2'),
+        url('../fonts/SourceSansPro-Regular.woff') format('woff'),
+        url('../fonts/SourceSansPro-Regular.otf') format('opentype');
  }
 
 @font-face {
-    font-family: "Source Sans Pro";
+    font-family: 'Source Sans Pro';
     font-style: normal;
     font-weight: 600;
     font-display: swap;
-    src: url('../fonts/SourceSansPro-SemiBold.woff2') format("woff2"),
-        url('../fonts/SourceSansPro-SemiBold.woff') format("woff"),
-        url('../fonts/SourceSansPro-SemiBold.otf') format("opentype");
+    src: url('../fonts/SourceSansPro-SemiBold.woff2') format('woff2'),
+        url('../fonts/SourceSansPro-SemiBold.woff') format('woff'),
+        url('../fonts/SourceSansPro-SemiBold.otf') format('opentype');
 }
 
 @font-face {
-    font-family: "Source Sans Pro";
+    font-family: 'Source Sans Pro';
     font-style: normal;
     font-weight: 700;
     font-display: swap;
-    src: url('../fonts/SourceSansPro-Bold.woff2') format("woff2"),
-        url('../fonts/SourceSansPro-Bold.woff') format("woff"),
-            url('../fonts/SourceSansPro-Bold.otf') format("opentype");
+    src: url('../fonts/SourceSansPro-Bold.woff2') format('woff2'),
+        url('../fonts/SourceSansPro-Bold.woff') format('woff'),
+            url('../fonts/SourceSansPro-Bold.otf') format('opentype');
 }
 
 @font-face {
-    font-family: "CC Accidenz Commons";
+    font-family: 'CC Accidenz Commons';
     font-style: normal;
     font-weight: 400;
     font-display: swap;
-    src: url('../fonts/CCAccidenzCommons-medium.otf') format("opentype");
+    src: url('../fonts/CCAccidenzCommons-medium.otf') format('opentype');
 }
 
 
@@ -82,7 +82,7 @@
     --vocabulary-neutral-color-dark-gray: #767676;
 
     /* brand typsetting */
-    --vocabulary-brand-typeset-nav-family: "Roboto Condensed";
+    --vocabulary-brand-typeset-nav-family: 'Roboto Condensed';
     --vocabulary-brand-typeset-nav-weight: bold;
     --vocabulary-brand-typeset-nav-color: #767676;
 
@@ -121,8 +121,9 @@
 
         a:before {
             --icon-sprite: var(--icon-name);
-            --icon-sprite- color: white;
+            --icon-sprite-color: white;
             --icon-sprite-size: .8em;
+        }
 
     */
 

--- a/src/css/vocabulary.css
+++ b/src/css/vocabulary.css
@@ -240,7 +240,7 @@ main > header:before {
     left: -33.333%;
     top: 0;
     z-index: -1;
-    content: "";
+    content: '';
 
     background: #F5F5F5;
 }
@@ -718,7 +718,7 @@ main .attribution-list button.expand-attribution {
     cursor: pointer;
     border: 1px solid black;
     border-radius: 3px;
-    font-family: "Source Sans Pro";
+    font-family: 'Source Sans Pro';
 }
 
 main .attribution-list button.expand-attribution.selected {
@@ -857,7 +857,7 @@ body > header .masthead .identity-logo.product {
 
     text-decoration: none;
     text-indent: 42px;
-    font-family: "CC Accidenz Commons";
+    font-family: 'CC Accidenz Commons';
     font-weight: normal;
     text-transform: lowercase;
     letter-spacing: -1px;
@@ -941,7 +941,7 @@ body > header .ancillary-menu {
     /* right: var(--vocabulary-page-edges-space); */
     right: 0;
 
-    font-family: "Source Sans Pro";
+    font-family: 'Source Sans Pro';
     font-style: normal;
     font-weight: 600;
     font-size: .8em;
@@ -1214,9 +1214,9 @@ body > footer {
     display: grid;
     grid-template-columns: 1fr 1fr 1fr 1fr;
     grid-template-areas:
-    "logo nav nav nav"
-    "contact subscribe subscribe donate"
-    "contact license license donate";
+    'logo nav nav nav'
+    'contact subscribe subscribe donate'
+    'contact license license donate';
     gap: 40px;
     padding: 40px var(--vocabulary-page-edges-space);
 
@@ -1353,7 +1353,7 @@ body > footer .subscribe form input {
     -webkit-appearance: none;
     background-color: transparent;
     color: rgb(118, 118, 118);
-    font-family: "Source Sans Pro", sans-serif;
+    font-family: 'Source Sans Pro', sans-serif;
     font-size: 1em;
     font-weight: 600;
     line-height: 1.3;
@@ -1378,7 +1378,7 @@ body > footer .subscribe form input.button {
     padding: 1.1em;
 
     cursor: pointer;
-    font-family: "Roboto Condensed", sans-serif;
+    font-family: 'Roboto Condensed', sans-serif;
     font-size: 1.125rem;
     text-align: center;
     text-transform: uppercase;


### PR DESCRIPTION
## Related
- Related to #5 by @possumbilities 

## Description
Consistently use single quotes in CSS

Rationale:
- inconsistent usage reduces ease of reading and pattern matching
- majority of quotes were single
- single quotes appears to be the industry norm

## Technical details
Quotation marks prior to this PR:
| File | Total | Single | Double |
| --- | --: | --: | --: |
| `src/css/library-vars.css` | 132 |  86 (65%) | 46 (35%) |
| `src/css/vocabulary.css:` | 142 | 124 (87%) | 18 (13%) | 

NOTE: _**If**_ we end up adopting the [Google HTML/CSS Style Guide](https://google.github.io/styleguide/htmlcssguide.html) as a base, the quotation marks in the URI values will need to be removed per [4.2.8 CSS Quotation Marks](https://google.github.io/styleguide/htmlcssguide.html#CSS_Quotation_Marks):
> Use single (`''`) rather than double (`""`) quotation marks for attribute selectors and property values.
>
> Do not use quotation marks in URI values (`url()`).

<!--
## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or comment out this section entirely. -->

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
