### PR TITLE
BugFix : Corrected file path for logo images

### DIFF
--- a/specimen/contexts/archive-page.html
+++ b/specimen/contexts/archive-page.html
@@ -294,10 +294,10 @@
         <p>Except where otherwise <a href="/policies/#license">noted</a>, content on this site is licensed under a <a href="/licenses/by/4.0/">Creative Commons Attribution 4.0 International license</a>. Icons by <a href="https://fontawesome.com/" target="_blank">Font Awesome</a>.</p>
 
         <svg>
-            <use href="../../../src/svg/cc/icons/cc-icons.svg#cc-logo"></use>
+            <use href="../../src/svg/cc/icons/cc-icons.svg#cc-logo"></use>
         </svg>
         <svg>
-            <use href="../../../src/svg/cc/icons/cc-icons.svg#cc-by"></use>
+            <use href="../../src/svg/cc/icons/cc-icons.svg#cc-by"></use>
         </svg>
     </div>
 

--- a/specimen/contexts/blog-index.html
+++ b/specimen/contexts/blog-index.html
@@ -647,10 +647,10 @@
         <p>Except where otherwise <a href="/policies/#license">noted</a>, content on this site is licensed under a <a href="/licenses/by/4.0/">Creative Commons Attribution 4.0 International license</a>. Icons by <a href="https://fontawesome.com/" target="_blank">Font Awesome</a>.</p>
 
         <svg>
-            <use href="../../../src/svg/cc/icons/cc-icons.svg#cc-logo"></use>
+            <use href="../../src/svg/cc/icons/cc-icons.svg#cc-logo"></use>
         </svg>
         <svg>
-            <use href="../../../src/svg/cc/icons/cc-icons.svg#cc-by"></use>
+            <use href="../../src/svg/cc/icons/cc-icons.svg#cc-by"></use>
         </svg>
     </div>
 

--- a/specimen/contexts/blog-post.html
+++ b/specimen/contexts/blog-post.html
@@ -340,10 +340,10 @@
         <p>Except where otherwise <a href="/policies/#license">noted</a>, content on this site is licensed under a <a href="/licenses/by/4.0/">Creative Commons Attribution 4.0 International license</a>. Icons by <a href="https://fontawesome.com/" target="_blank">Font Awesome</a>.</p>
 
         <svg>
-            <use href="../../../src/svg/cc/icons/cc-icons.svg#cc-logo"></use>
+            <use href="../../src/svg/cc/icons/cc-icons.svg#cc-logo"></use>
         </svg>
         <svg>
-            <use href="../../../src/svg/cc/icons/cc-icons.svg#cc-by"></use>
+            <use href="../../src/svg/cc/icons/cc-icons.svg#cc-by"></use>
         </svg>
     </div>
 

--- a/specimen/contexts/default-page.html
+++ b/specimen/contexts/default-page.html
@@ -257,10 +257,10 @@
         <p>Except where otherwise <a href="/policies/#license">noted</a>, content on this site is licensed under a <a href="/licenses/by/4.0/">Creative Commons Attribution 4.0 International license</a>. Icons by <a href="https://fontawesome.com/" target="_blank">Font Awesome</a>.</p>
 
         <svg>
-            <use href="../../../src/svg/cc/icons/cc-icons.svg#cc-logo"></use>
+            <use href="../../src/svg/cc/icons/cc-icons.svg#cc-logo"></use>
         </svg>
         <svg>
-            <use href="../../../src/svg/cc/icons/cc-icons.svg#cc-by"></use>
+            <use href="../../src/svg/cc/icons/cc-icons.svg#cc-by"></use>
         </svg>
     </div>
 

--- a/specimen/contexts/home-index.html
+++ b/specimen/contexts/home-index.html
@@ -513,10 +513,10 @@
         <p>Except where otherwise <a href="/policies/#license">noted</a>, content on this site is licensed under a <a href="/licenses/by/4.0/">Creative Commons Attribution 4.0 International license</a>. Icons by <a href="https://fontawesome.com/" target="_blank">Font Awesome</a>.</p>
 
         <svg>
-            <use href="../../../src/svg/cc/icons/cc-icons.svg#cc-logo"></use>
+            <use href="../../src/svg/cc/icons/cc-icons.svg#cc-logo"></use>
         </svg>
         <svg>
-            <use href="../../../src/svg/cc/icons/cc-icons.svg#cc-by"></use>
+            <use href="../../src/svg/cc/icons/cc-icons.svg#cc-by"></use>
         </svg>
     </div>
 

--- a/specimen/contexts/license-page.html
+++ b/specimen/contexts/license-page.html
@@ -160,10 +160,10 @@
         <p>Except where otherwise <a href="/policies/#license">noted</a>, content on this site is licensed under a <a href="/licenses/by/4.0/">Creative Commons Attribution 4.0 International license</a>. Icons by <a href="https://fontawesome.com/" target="_blank">Font Awesome</a>.</p>
 
         <svg>
-            <use href="../../../src/svg/cc/icons/cc-icons.svg#cc-logo"></use>
+            <use href="../../src/svg/cc/icons/cc-icons.svg#cc-logo"></use>
         </svg>
         <svg>
-            <use href="../../../src/svg/cc/icons/cc-icons.svg#cc-by"></use>
+            <use href="../../src/svg/cc/icons/cc-icons.svg#cc-by"></use>
         </svg>
     </div>
 

--- a/specimen/contexts/person-page.html
+++ b/specimen/contexts/person-page.html
@@ -256,10 +256,10 @@
         <p>Except where otherwise <a href="/policies/#license">noted</a>, content on this site is licensed under a <a href="/licenses/by/4.0/">Creative Commons Attribution 4.0 International license</a>. Icons by <a href="https://fontawesome.com/" target="_blank">Font Awesome</a>.</p>
 
         <svg>
-            <use href="../../../src/svg/cc/icons/cc-icons.svg#cc-logo"></use>
+            <use href="../../src/svg/cc/icons/cc-icons.svg#cc-logo"></use>
         </svg>
         <svg>
-            <use href="../../../src/svg/cc/icons/cc-icons.svg#cc-by"></use>
+            <use href="../../src/svg/cc/icons/cc-icons.svg#cc-by"></use>
         </svg>
     </div>
 

--- a/specimen/contexts/program-index.html
+++ b/specimen/contexts/program-index.html
@@ -260,10 +260,10 @@
         <p>Except where otherwise <a href="/policies/#license">noted</a>, content on this site is licensed under a <a href="/licenses/by/4.0/">Creative Commons Attribution 4.0 International license</a>. Icons by <a href="https://fontawesome.com/" target="_blank">Font Awesome</a>.</p>
 
         <svg>
-            <use href="../../../src/svg/cc/icons/cc-icons.svg#cc-logo"></use>
+            <use href="../../src/svg/cc/icons/cc-icons.svg#cc-logo"></use>
         </svg>
         <svg>
-            <use href="../../../src/svg/cc/icons/cc-icons.svg#cc-by"></use>
+            <use href="../../src/svg/cc/icons/cc-icons.svg#cc-by"></use>
         </svg>
     </div>
 

--- a/specimen/contexts/program-page.html
+++ b/specimen/contexts/program-page.html
@@ -241,10 +241,10 @@
         <p>Except where otherwise <a href="/policies/#license">noted</a>, content on this site is licensed under a <a href="/licenses/by/4.0/">Creative Commons Attribution 4.0 International license</a>. Icons by <a href="https://fontawesome.com/" target="_blank">Font Awesome</a>.</p>
 
         <svg>
-            <use href="../../../src/svg/cc/icons/cc-icons.svg#cc-logo"></use>
+            <use href="../../src/svg/cc/icons/cc-icons.svg#cc-logo"></use>
         </svg>
         <svg>
-            <use href="../../../src/svg/cc/icons/cc-icons.svg#cc-by"></use>
+            <use href="../../src/svg/cc/icons/cc-icons.svg#cc-by"></use>
         </svg>
     </div>
 

--- a/specimen/contexts/search-index.html
+++ b/specimen/contexts/search-index.html
@@ -282,10 +282,10 @@
         <p>Except where otherwise <a href="/policies/#license">noted</a>, content on this site is licensed under a <a href="/licenses/by/4.0/">Creative Commons Attribution 4.0 International license</a>. Icons by <a href="https://fontawesome.com/" target="_blank">Font Awesome</a>.</p>
 
         <svg>
-            <use href="../../../src/svg/cc/icons/cc-icons.svg#cc-logo"></use>
+            <use href="../../src/svg/cc/icons/cc-icons.svg#cc-logo"></use>
         </svg>
         <svg>
-            <use href="../../../src/svg/cc/icons/cc-icons.svg#cc-by"></use>
+            <use href="../../src/svg/cc/icons/cc-icons.svg#cc-by"></use>
         </svg>
     </div>
 

--- a/specimen/contexts/team-index.html
+++ b/specimen/contexts/team-index.html
@@ -212,10 +212,10 @@
         <p>Except where otherwise <a href="/policies/#license">noted</a>, content on this site is licensed under a <a href="/licenses/by/4.0/">Creative Commons Attribution 4.0 International license</a>. Icons by <a href="https://fontawesome.com/" target="_blank">Font Awesome</a>.</p>
 
         <svg>
-            <use href="../../../src/svg/cc/icons/cc-icons.svg#cc-logo"></use>
+            <use href="../../src/svg/cc/icons/cc-icons.svg#cc-logo"></use>
         </svg>
         <svg>
-            <use href="../../../src/svg/cc/icons/cc-icons.svg#cc-by"></use>
+            <use href="../../src/svg/cc/icons/cc-icons.svg#cc-by"></use>
         </svg>
     </div>
 

--- a/specimen/contexts/walkthrough-page.html
+++ b/specimen/contexts/walkthrough-page.html
@@ -168,10 +168,10 @@
         <p>Except where otherwise <a href="/policies/#license">noted</a>, content on this site is licensed under a <a href="/licenses/by/4.0/">Creative Commons Attribution 4.0 International license</a>. Icons by <a href="https://fontawesome.com/" target="_blank">Font Awesome</a>.</p>
 
         <svg>
-            <use href="../../../src/svg/cc/icons/cc-icons.svg#cc-logo"></use>
+            <use href="../../src/svg/cc/icons/cc-icons.svg#cc-logo"></use>
         </svg>
         <svg>
-            <use href="../../../src/svg/cc/icons/cc-icons.svg#cc-by"></use>
+            <use href="../../src/svg/cc/icons/cc-icons.svg#cc-by"></use>
         </svg>
     </div>
 

--- a/specimen/index-logo.html
+++ b/specimen/index-logo.html
@@ -150,10 +150,10 @@
         <p>Except where otherwise <a href="/policies/#license">noted</a>, content on this site is licensed under a <a href="/licenses/by/4.0/">Creative Commons Attribution 4.0 International license</a>. Icons by <a href="https://fontawesome.com/" target="_blank">Font Awesome</a>.</p>
 
         <svg>
-            <use href="../../src/svg/cc/icons/cc-icons.svg#cc-logo"></use>
+            <use href="../src/svg/cc/icons/cc-icons.svg#cc-logo"></use>
         </svg>
         <svg>
-            <use href="../../src/svg/cc/icons/cc-icons.svg#cc-by"></use>
+            <use href="../src/svg/cc/icons/cc-icons.svg#cc-by"></use>
         </svg>
     </div>
 

--- a/specimen/product-logo.html
+++ b/specimen/product-logo.html
@@ -145,10 +145,10 @@
         <p>Except where otherwise <a href="/policies/#license">noted</a>, content on this site is licensed under a <a href="/licenses/by/4.0/">Creative Commons Attribution 4.0 International license</a>. Icons by <a href="https://fontawesome.com/" target="_blank">Font Awesome</a>.</p>
 
         <svg>
-            <use href="../../src/svg/cc/icons/cc-icons.svg#cc-logo"></use>
+            <use href="../src/svg/cc/icons/cc-icons.svg#cc-logo"></use>
         </svg>
         <svg>
-            <use href="../../src/svg/cc/icons/cc-icons.svg#cc-by"></use>
+            <use href="../src/svg/cc/icons/cc-icons.svg#cc-by"></use>
         </svg>
     </div>
 

--- a/specimen/tests/grid-sidebar.html
+++ b/specimen/tests/grid-sidebar.html
@@ -186,10 +186,10 @@
         <p>Except where otherwise <a href="/policies/#license">noted</a>, content on this site is licensed under a <a href="/licenses/by/4.0/">Creative Commons Attribution 4.0 International license</a>. Icons by <a href="https://fontawesome.com/" target="_blank">Font Awesome</a>.</p>
 
         <svg>
-            <use href="/vocabulary/svg/cc/icons/cc-icons.svg#cc-logo"></use>
+            <use href="../../src/svg/cc/icons/cc-icons.svg#cc-logo"></use>
         </svg>
         <svg>
-            <use href="/vocabulary/svg/cc/icons/cc-icons.svg#cc-by"></use>
+            <use href="../../src/svg/cc/icons/cc-icons.svg#cc-by"></use>
         </svg>
     </div>
 

--- a/specimen/tests/grid.html
+++ b/specimen/tests/grid.html
@@ -186,10 +186,10 @@
         <p>Except where otherwise <a href="/policies/#license">noted</a>, content on this site is licensed under a <a href="/licenses/by/4.0/">Creative Commons Attribution 4.0 International license</a>. Icons by <a href="https://fontawesome.com/" target="_blank">Font Awesome</a>.</p>
 
         <svg>
-            <use href="/vocabulary/svg/cc/icons/cc-icons.svg#cc-logo"></use>
+            <use href="../../src/svg/cc/icons/cc-icons.svg#cc-logo"></use>
         </svg>
         <svg>
-            <use href="/vocabulary/svg/cc/icons/cc-icons.svg#cc-by"></use>
+            <use href="../../src/svg/cc/icons/cc-icons.svg#cc-logo"></use>
         </svg>
     </div>
 

--- a/specimen/tests/kitchensink.html
+++ b/specimen/tests/kitchensink.html
@@ -616,10 +616,10 @@
         <p>Except where otherwise <a href="/policies/#license">noted</a>, content on this site is licensed under a <a href="/licenses/by/4.0/">Creative Commons Attribution 4.0 International license</a>. Icons by <a href="https://fontawesome.com/" target="_blank">Font Awesome</a>.</p>
 
         <svg>
-            <use href="../../../src/svg/cc/icons/cc-icons.svg#cc-logo"></use>
+            <use href="../../src/svg/cc/icons/cc-icons.svg#cc-logo"></use>
         </svg>
         <svg>
-            <use href="../../../src/svg/cc/icons/cc-icons.svg#cc-by"></use>
+            <use href="../../src/svg/cc/icons/cc-icons.svg#cc-by"></use>
         </svg>
     </div>
 


### PR DESCRIPTION
## Fixes

- Fixes #323  by @SumaiyaaRq

## Description
This PR addresses an issue where the logo images were not displayed due to an incorrect file path. The current path was pointing to the wrong directory. The path has been corrected such that the logos are correctly displayed in the Footer region. 

## Technical details
1. The path in files of  `contexts` and `tests` folder has been corrected by changing the relative path. 
2. In the `specimen` folder the path has been changed by adding the correct directory for the files `grid-sidebar.html` and `grid.html` . 
## Tests
1. Open any of the pages in specimen or tests folder
2. Navigate to the Footer region.
3. Check if logos cc-logo & cc-by are present .
4. See correction .

## Screenshots
<img width="1143" alt="Screenshot 2024-11-19 at 8 43 37 PM" src="https://github.com/user-attachments/assets/684b6f7c-d28a-4ede-b4d9-e73eaeec03c2">


## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
