### PR TITLE
correct main content area padding issue, correct flex snapping of figure element to full on smaller viewports

### DIFF
--- a/src/css/vocabulary.css
+++ b/src/css/vocabulary.css
@@ -1958,6 +1958,9 @@ body > footer .license svg {
         padding: 0 var(--vocabulary-page-edges-space);
     }
 
+    main > *:not(header) {
+        padding: 0 var(--vocabulary-page-edges-space);
+    }
 
     main > .posts {
         padding: 0 var(--vocabulary-page-edges-space); 

--- a/src/css/vocabulary.css
+++ b/src/css/vocabulary.css
@@ -1968,6 +1968,15 @@ body > footer .license svg {
         flex: initial;
     }
 
+    .person-page main > header {
+        padding-left: var(--vocabulary-page-edges-space);
+        padding-right: var(--vocabulary-page-edges-space);
+    }
+
+    .person-page main > header:before { 
+        left: 0;
+    }
+
     .search-index main > header {
         padding-left: var(--vocabulary-page-edges-space);
         padding-right: var(--vocabulary-page-edges-space);
@@ -1977,7 +1986,6 @@ body > footer .license svg {
         left: 0;
     }
     
-
     .team-index main > header {
         padding: 0 var(--vocabulary-page-edges-space);
     }

--- a/src/css/vocabulary.css
+++ b/src/css/vocabulary.css
@@ -1133,7 +1133,7 @@ body > header .explore-panel nav ul li p {
 
 body > article.attention {
     grid-column: 1 / span 11;
-    padding: 1em 5%;
+    padding: 1em var(--vocabulary-page-edges-space);
 
     background: var(--vocabulary-brand-color-soft-green);
     font-family: 'Source Sans Pro';
@@ -1523,7 +1523,7 @@ body > footer .license svg {
 }
 
 .blog-index main .posts.featured ul {    
-    padding: 0 5%;
+    padding: 0 var(--vocabulary-page-edges-space);
 }
 
 .blog-index main .posts.featured ul li {
@@ -1901,7 +1901,7 @@ body > footer .license svg {
     }
 
     .blog-index main .posts {
-        padding: 0 5%;
+        padding: 0 var(--vocabulary-page-edges-space);
     }
 
     .blog-index main footer .attribution-list ul.expand {
@@ -1951,7 +1951,16 @@ body > footer .license svg {
     }
 
     main .content {
-        padding: var(--vocabulary-page-edges-space);
+        padding: 0 var(--vocabulary-page-edges-space);
+    }
+
+    main:has( > aside.sidebar) > aside.sidebar { 
+        padding: 0 var(--vocabulary-page-edges-space);
+    }
+
+
+    main > .posts {
+        padding: 0 var(--vocabulary-page-edges-space); 
     }
 
     .posts article figure {
@@ -1959,12 +1968,22 @@ body > footer .license svg {
         flex: initial;
     }
 
+    .search-index main > header {
+        padding-left: var(--vocabulary-page-edges-space);
+        padding-right: var(--vocabulary-page-edges-space);
+    }
+
+    .search-index main > header:before { 
+        left: 0;
+    }
+    
+
     .team-index main > header {
-        padding: 0 5%;
+        padding: 0 var(--vocabulary-page-edges-space);
     }
 
     .team-index main article.persons {
-        padding: 0 5%;
+        padding: 0 var(--vocabulary-page-edges-space);
     }
 
     .team-index main article.persons ul {
@@ -2008,6 +2027,11 @@ body > footer .license svg {
 
     main article.posts.related ul {
         grid-template-columns: 1fr;
+    }
+
+    .posts .post figure {
+        width: 100%;
+        flex: initial;
     }
 }
 


### PR DESCRIPTION
## Description
- fixes #60 
- fixes #88 
- fixes #142 
- fixes #188 
- fixes #262 
- fixes #276 
- replaces padding listed as manually `5%` to the `--vocabulary-page-edges-space` css variable
- corrects `figure` element flex behavior on smaller viewports, so that it snaps to full size, rather than a cramped 50% rendering behavior.

## Technical Details
- this PR causes an override of:
  - https://github.com/creativecommons/vocabulary-theme/issues/87
  - which will result in the need for a new sync Issue for `v1.9` of `vocabulary-theme` _(post release)_

## Tests

### page-level contexts
* `archive-page` : https://deploy-preview-334--vocabulary-docs.netlify.app/specimen/contexts/archive-page.html
* `default-page` : https://deploy-preview-334--vocabulary-docs.netlify.app/specimen/contexts/default-page.html
* `person-page` : https://deploy-preview-334--vocabulary-docs.netlify.app/specimen/contexts/person-page.html
* `search-index` : https://deploy-preview-334--vocabulary-docs.netlify.app/specimen/contexts/search-index.html

### general tests
* `kitchensink` : https://deploy-preview-334--vocabulary-docs.netlify.app/specimen/tests/kitchensink.html

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
