### PR TITLE
move aspect controls to figure, prevent overly large images from "crunching" along vertical axis on `person-page` context

### DIFF
--- a/src/css/vocabulary.css
+++ b/src/css/vocabulary.css
@@ -1747,14 +1747,14 @@ body > footer .license svg {
     top: 3.4em;
     left: 0;
     width: 30%;
+    max-height: 21.8rem;
+    overflow: hidden;
+    border: 16px solid white;
 }
 
 .person-page main > header figure img {
     box-sizing: border-box;
     width: 100%;
-    max-height: 21.8rem;
-
-    border: 16px solid white;
 }
 
 .person-page main > header .bio {


### PR DESCRIPTION
## Fixes
- Fixes #343

## Description
This moves the aspect bounding to the `figure` rather than the `img` element, allow the box to remain the correct size, while cropping the image along the vertical axis should it be too tall without crunching it with distorition.

## Screenshots

### Before
<img width="912" alt="Screen Shot 2025-05-06 at 3 41 25 PM" src="https://github.com/user-attachments/assets/b28c3f84-4855-42f3-b732-8aa9a4e7c29b" />


### After
<img width="841" alt="Screen Shot 2025-05-06 at 3 41 17 PM" src="https://github.com/user-attachments/assets/7702546a-a049-48b0-8134-700a75fe50fb" />

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
