### PR TITLE
correct logo pathways, correct mobile nav menu behavior and display 

### DIFF
--- a/src/css/vocabulary.css
+++ b/src/css/vocabulary.css
@@ -1749,7 +1749,7 @@ body > header .masthead .identity-logo:before {
     /* allows for color manipulation of svg */
     background-color: black;
     
-    mask-image: url('../../src/svg/cc/logos/cc/logomark.svg');
+    mask-image: url('../svg/cc/logos/cc/logomark.svg');
     mask-repeat: no-repeat;
     cursor: pointer;
 
@@ -1803,6 +1803,10 @@ body > header .masthead .identity-logo.product:before {
     vertical-align: bottom;
 
 } */
+
+body > header button.expand-menu {
+    display: none;
+}
 
 body > header .masthead .primary-menu ul {
     display: flex;
@@ -2402,7 +2406,7 @@ body > footer .identity-logo:before {
     height: 82px;
     width: 340px;
     background-color: white;
-    mask-image: url('../../src/svg/cc/logos/cc/logomark.svg');
+    mask-image: url('../svg/cc/logos/cc/logomark.svg');
     mask-repeat: no-repeat;
     cursor: pointer;
     grid-area: logo;

--- a/src/js/vocabulary.js
+++ b/src/js/vocabulary.js
@@ -1,3 +1,12 @@
+const menuButton = document.querySelector('button.expand-menu');
+const menuPanel = document.querySelector('.primary-menu');
+
+if(menuButton !== null && menuPanel !== null) {
+    menuButton.addEventListener('click', (event) => {
+        menuPanel.classList.toggle('expand');
+    });
+}
+
 const menusWithChildren = document.querySelectorAll('main > aside.sidebar nav > ul > li:has(ul) > a');
 
 menusWithChildren.forEach((menu) => {


### PR DESCRIPTION
<!-- ⚠️ Pull requests (PRs) that don't follow this template will be discarded. -->

## Description
<!-- Concisely describe what the pull request does. -->

- pulls in fixes found downstream in `vocabulary-theme`
- corrects the pathways of the logo in header/footer in `vocabulary.css`
- adds back mobile nav button functionality in `vocabulary.js`
- adds back mobile nav button display settings in `vocabulary.css`

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] I have read and understood the Developer Certificate of Origin (DCO), below, which covers the contents of this pull request (PR).
- [x] My pull request doesn't include code or content generated with AI (also see [Avoiding generative AI development tools — Creative Commons Open Source][no-ai]).
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated unit tests and/or test scripts for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[no-ai]: https://opensource.creativecommons.org/blog/entries/2025-12-01-avoiding-gen-ai-tools/
[best_practices]: https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
